### PR TITLE
TR_query() function signature matches TR_inspect()

### DIFF
--- a/SCOR/threat-response-api-example.py
+++ b/SCOR/threat-response-api-example.py
@@ -89,13 +89,13 @@ def TR_check_auth(function, param):
     return response
 
 
-def TR_query(observable):
+def TR_query(text_block):
     ''' Pass the functions and parameters to check_auth to query the API
         Return the final response
     '''
     response = TR_check_auth(TR_inspect, text_block)
     inspect_output = response.text
-    response = TR_check_auth(TR_enrich, inspect_output)
+    response = TR_check_auth(TR_enrich, inspect_output)  # TR_enrich() is undefined
     return response
 
 def TR_inspect(text_block):


### PR DESCRIPTION
`observable` is not being used in this function but `text_block` is so change the function signature of `TR_query()` to match `TR_inspect()` just below.  This resolves both the unused variable name `observable` and the undefined variable name `text_block`.

The user of this example will still need to define their own `TR_enrich()` function.