### PR TITLE
Avoid SyntaxWarning on Python >= 3.8

### DIFF
--- a/python_ruby_and_bash/parsing_auth_log/logalyzer.py
+++ b/python_ruby_and_bash/parsing_auth_log/logalyzer.py
@@ -12,7 +12,7 @@ import ParseLogs
 
 # callback for the user flag
 def user_call(option, opt_str, value, parser):
-    if len(parser.rargs) is not 0:
+    if len(parser.rargs) != 0:
         value = parser.rargs[0]
     else:
         value = None
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args()
 
     # if they're trying to access /var/log/auth.log without proper privs, bail
-    if not os.getuid() is 0 and options.log is None:
+    if not os.getuid() == 0 and options.log is None:
         print("[-] Please run with SUDO")
         sys.exit(1)
 


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> 0 is 0
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```