### PR TITLE
Fix TypeError issue in cookie_stealer

### DIFF
--- a/programming_and_scripting_for_cybersecurity/exploitation/cookie_stealer.py
+++ b/programming_and_scripting_for_cybersecurity/exploitation/cookie_stealer.py
@@ -19,7 +19,7 @@ def cookie():
 
     cookie = request.args.get('c')
     f = open("cookies.txt","a")
-    f.write(cookie + ' ' + str(datetime.now()) + '\n')
+    f.write(str(cookie) + ' ' + str(datetime.now()) + '\n')
     f.close()
 
     # redirecting the user back to the vulnerable application


### PR DESCRIPTION
Currently if we start cookie_stealer and request will be triggered to server, error will be happened:
```python
 * Running on http://10.0.2.15:1337/ (Press CTRL+C to quit)
[2022-02-14 00:30:51,370] ERROR in app: Exception on / [GET]
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python3/dist-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python3/dist-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python3/dist-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/lib/python3/dist-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python3/dist-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/root/h4cker/programming_and_scripting_for_cybersecurity/exploitation/cookie_stealer.py", line 22, in cookie
    f.write(cookie + ' ' + str(datetime.now()) + '\n')
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
10.0.2.15 - - [14/Feb/2022 00:30:51] "GET / HTTP/1.1" 500 -
```

To fix the issue, need to add str() for cookie variable before write