### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,51 @@
+# This workflow automatically marks issues and pull requests as stale after a period of inactivity
+# and eventually closes them if no further activity occurs.
+#
+# You can adjust the behavior by modifying this file, such as changing the schedule,
+# messages, and labels used.
+#
+# For more information, visit:
+# https://github.com/actions/stale
+
+name: Auto-mark and close stale issues and pull requests
+
+on:
+  schedule:
+    # Run daily at 5:17 AM UTC
+    - cron: '17 5 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Run stale action
+      uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        
+        # Customizable stale behavior
+        days-before-stale: 30          # Mark issues/PRs as stale after 30 days of inactivity
+        days-before-close: 7           # Close stale issues/PRs 7 days after being marked stale
+        stale-issue-message: >
+          This issue has been automatically marked as stale due to inactivity for 30 days. 
+          If you believe this issue is still relevant, please comment to remove the stale label. 
+          Otherwise, it will be closed in 7 days. Thank you for your contributions!
+        stale-pr-message: >
+          This pull request has been automatically marked as stale due to inactivity for 30 days. 
+          If you still plan to work on this, please comment or push new changes to prevent it from being closed. 
+          Otherwise, it will be closed in 7 days. Thank you for your contributions!
+        
+        # Labels for tracking stale issues/PRs
+        stale-issue-label: 'stale-issue'
+        stale-pr-label: 'stale-pr'
+        
+        # Optional exclusions
+        exempt-issue-labels: 'pinned,important'  # Exclude issues with these labels from being marked stale
+        exempt-pr-labels: 'work-in-progress'     # Exclude PRs with these labels from being marked stale
+
+        # Enable debugging for more visibility
+        debug-only: false


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically manage stale issues and pull requests. The workflow marks issues and PRs as stale after a period of inactivity and eventually closes them if no further activity occurs.

Workflow automation:

* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894R1-R51): Added a workflow to automatically mark issues and pull requests as stale after 30 days of inactivity and close them after an additional 7 days if no further activity occurs. The workflow runs daily at 5:17 AM UTC and includes customizable messages, labels, and exclusions.