### PR TITLE
organizing learning platforms

### DIFF
--- a/vulnerable_servers/README.md
+++ b/vulnerable_servers/README.md
@@ -48,8 +48,13 @@ The following is a collection of vulnerable servers (VMs) or websites that you c
 
 ## Learning Platforms and VMs
 - [VulnHub](https://www.vulnhub.com)
+
+### Commercial (with free tiers)
 - [Hack the Box](https://www.hackthebox.eu/)
 - [TryHackMe](https://tryhackme.com/)
-- [eLearn Security](https://www.elearnsecurity.com/)
 - [PentesterLab](https://pentesterlab.com/)
+
+## Commercial Learning Providers (require registration)
+- [O'Reilly](https://www.oreilly.com/) - access to thousands of books, learning paths, video courses, labs, and live training.
 - [CyberPython](https://pythoncyber.go.ro/)
+- [eLearn Security](https://www.elearnsecurity.com/)


### PR DESCRIPTION
This pull request includes updates to the `vulnerable_servers/README.md` file, specifically restructuring and categorizing the list of learning platforms and VMs.

Changes to `vulnerable_servers/README.md`:

* Added a new section "Commercial (with free tiers)" and moved `Hack the Box` and `TryHackMe` under this section.
* Added a new section "Commercial Learning Providers (require registration)" and included `O'Reilly`, `CyberPython`, and `eLearn Security` under this section.