### PR TITLE
Update README.md

### DIFF
--- a/fuzzing_resources/README.md
+++ b/fuzzing_resources/README.md
@@ -1,7 +1,7 @@
 # Fuzzing Resources
 
 ## Commercial Fuzzers
-- [Synopsis Defensics](https://www.synopsys.com/software-integrity/security-testing/fuzz-testing.html)
+- [BlackDuck Defensics](https://www.blackduck.com/fuzz-testing.html)
 - [Code Intelligence](https://www.code-intelligence.com/)
 - [Mayhem for Code](https://forallsecure.com/mayhem-for-code)
 - [BeyondSecurity Fuzzer](https://www.beyondsecurity.com/solutions/bestorm-dynamic-application-security-testing)


### PR DESCRIPTION
This pull request includes a small change to the `fuzzing_resources/README.md` file. The change updates the link for a commercial fuzzer from "Synopsis Defensics" to "BlackDuck Defensics".

* [`fuzzing_resources/README.md`](diffhunk://#diff-8029403d293806026f290f066892ffa225da8a9dfd177852e29bebd0be655054L4-R4): Updated the link for "Synopsis Defensics" to "BlackDuck Defensics".