### PR TITLE
Update ai_security_tools.md

### DIFF
--- a/ai_research/ai_security_tools.md
+++ b/ai_research/ai_security_tools.md
@@ -2,35 +2,35 @@
 
 This is a work in progress, curated list of AI Security tools:
 
-## Model Testing
-_Products that examine or test models for security issues of various kinds._
+## Open Source Tools for AI Red Teaming
 
-* [HiddenLayer Model Scanner](https://hiddenlayer.com/model-scanner/) - Scan models for vulnerabilities and supply chain issues.
-* [Plexiglass](https://github.com/kortex-labs/plexiglass) - A toolkit for detecting and protecting against vulnerabilities in Large Language Models (LLMs). 
-* [PurpleLlama](https://github.com/facebookresearch/PurpleLlama) - Set of tools from Meta to assess and improve LLM security. 
-* [Garak](https://garak.ai/) - A LLM vulnerability scanner. [code](https://github.com/leondz/garak/)
-* [CalypsoAI Platform](https://calypsoai.com/platform/) - Platform for testing and launching LLM applications securely.
-* [Lakera Red](https://www.lakera.ai/ai-red-teaming) - Automated safety and security assessments for your GenAI applications.
-* [jailbreak-evaluation](https://github.com/controllability/jailbreak-evaluation) - Python package for language model jailbreak evaluation. 
-* [Patronus AI](https://www.patronus.ai) - Automated testing of models to detect PII, copyrighted materials, and sensitive information in models.
-* [Adversa Red Teaming](https://adversa.ai/ai-red-teaming-llm/) - Continuous AI red teaming for LLMs.
-* [Advai](https://www.advai.co.uk) - Automates the tasks of stress-testing, red-teaming, and evaluating your AI systems for critical failure.
-* [Mindgard AI](https://mindgard.ai) - Identifies and remediates risks across AI models, GenAI, LLMs along with AI-powered apps and chatbots.
-* [Protect AI ModelScan](https://protectai.com/modelscan) - Scan models for serialization attacks. [code](https://github.com/protectai/modelscan)
-* [Protect AI Guardian](https://protectai.com/guardian) - Scan models for security issues or policy violations with auditing and reporting.
-* [TextFooler](https://github.com/jind11/TextFooler) - A model for natural language attacks on text classification and inference.
-* [LLMFuzzer](https://github.com/mnns/LLMFuzzer) - Fuzzing framework for LLMs.
-* [Prompt Security Fuzzer](https://www.prompt.security/fuzzer) - a fuzzer to find prompt injection vulnerabilities.
-* [OpenAttack](https://github.com/thunlp/OpenAttack) - a Python-based textual adversarial attack toolkit.
+### Predictive AI
+- [The Adversarial Robustness Toolbox (ART)](https://github.com/Trusted-AI/adversarial-robustness-toolbox)
+- [Armory](https://github.com/twosixlabs/armory)
+- [Foolbox](https://github.com/bethgelab/foolbox)
+- [DeepSec](https://github.com/ryderling/DEEPSEC)
+- [TextAttack](https://github.com/QData/TextAttack)
+
+### Generative AI
+- [PyRIT](https://github.com/Azure/PyRIT)
+- [Garak](https://github.com/NVIDIA/garak)
+- [Prompt Fuzzer](https://github.com/prompt-security/ps-fuzz)
+- [Guardrail](https://github.com/guardrails-ai/guardrails)
+- [Promptfoo](https://github.com/promptfoo/promptfoo)
+- [PlexyGlass](https://github.com/safellama/plexiglass)
+-  [PurpleLlama](https://github.com/facebookresearch/PurpleLlama)
+-  [jailbreak-evaluation](https://github.com/controllability/jailbreak-evaluation)
 
 ## Prompt Firewall and Redaction
 
 _Products that intercept prompts and responses and apply security or privacy rules to them. We've blended two categories here because some prompt firewalls just redact private data (and then reidentify in the response) while others focus on identifying and blocking attacks like injection attacks or stopping data leaks. Many of the products in this category do all of the above, which is why they've been combined._
 
+- [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) - Model Evaluation, monitoring, guardrails, inventory, AI asset discovery, and more.
+- [Robust Intelligence AI Firewall](https://www.robustintelligence.com/) - Now part of Cisco.
 - [Protect AI Rebuff](https://playground.rebuff.ai) - A LLM prompt injection detector. [![code](https://img.shields.io/github/license/protectai/rebuff)](https://github.com/protectai/rebuff/)
 - [Protect AI LLM Guard](https://protectai.com/llm-guard) - Suite of tools to protect LLM applications by helping you detect, redact, and sanitize LLM prompts and responses. [![code](https://img.shields.io/github/license/protectai/llm-guard)](https://github.com/protectai/llm-guard/)
 - [HiddenLayer AI Detection and Response](https://hiddenlayer.com/aidr/) - Proactively defend against threats to your LLMs.
-- [Robust Intelligence AI Firewall](https://www.robustintelligence.com/platform/ai-firewall-guardrails) - Real-time protection, automatically configured to address the vulnerabilities of each model.
+
 - [Vigil LLM](https://github.com/deadbits/vigil-llm) - Detect prompt injections, jailbreaks, and other potentially risky Large Language Model (LLM) inputs. ![code](https://img.shields.io/github/license/deadbits/vigil-llm)
 - [Lakera Guard](https://www.lakera.ai/lakera-guard) - Protection from prompt injections, data loss, and toxic content.
 - [Arthur Shield](https://www.arthur.ai/product/shield) - Built-in, real-time firewall protection against the biggest LLM risks.


### PR DESCRIPTION
This pull request includes significant updates to the `ai_research/ai_security_tools.md` file, reorganizing and expanding the list of AI security tools. The changes focus on categorizing tools more clearly and adding new entries.

Reorganization and expansion of AI security tools:

* Changed the section title from "Model Testing" to "Open Source Tools for AI Red Teaming" and divided it into "Predictive AI" and "Generative AI" subcategories.
* Added new tools under "Predictive AI": `The Adversarial Robustness Toolbox (ART)`, `Armory`, `Foolbox`, `DeepSec`, and `TextAttack`.
* Added new tools under "Generative AI": `PyRIT`, `Garak`, `Prompt Fuzzer`, `Guardrail`, and `Promptfoo`.
* Moved existing tools like `Garak`, `PlexyGlass`, `PurpleLlama`, and `jailbreak-evaluation` to the "Generative AI" subcategory.

Updates to the "Prompt Firewall and Redaction" section:

* Added `Cisco AI Defense` and `Robust Intelligence AI Firewall` to the list.
* Removed the duplicate entry for `Robust Intelligence AI Firewall`. (