### PR TITLE
Adding the Generated STIX example documents

### DIFF
--- a/threat_intelligence/stix_4f66bca89e4beb33758a46fb192b744779052b2e5e2e96e2b41d2fd093f61074.json
+++ b/threat_intelligence/stix_4f66bca89e4beb33758a46fb192b744779052b2e5e2e96e2b41d2fd093f61074.json
@@ -1,0 +1,88 @@
+{
+  "type": "bundle",
+  "id": "bundle--b4c5e4b3-4c1e-4c9f-8f5e-1f3c8e4c1e4d",
+  "objects": [
+    {
+      "type": "malware",
+      "id": "malware--4f66bca8-9e4b-4beb-3375-8a46fb192b7",
+      "created": "2025-02-14T20:05:11Z",
+      "modified": "2025-02-14T20:34:28Z",
+      "name": "DanaBot",
+      "is_family": false,
+      "malware_types": ["trojan"],
+      "first_seen": "2025-02-14T20:05:11Z",
+      "last_seen": "2025-02-14T20:34:28Z",
+      "labels": ["DanaBot", "exe"],
+      "file_extension": "exe",
+      "architecture": ["x86", "x64"],
+      "sample": {
+        "type": "file",
+        "name": "5db4153d9523b8773529bd898a6deac0.exe",
+        "size": 12546070,
+        "mime_type": "application/x-dosexec",
+        "hashes": {
+          "SHA-256": "4f66bca89e4beb33758a46fb192b744779052b2e5e2e96e2b41d2fd093f61074",
+          "SHA-1": "60572c719979b06664ae2feb8595db2d7a6f18ed",
+          "MD5": "5db4153d9523b8773529bd898a6deac0",
+          "SHA3-384": "e9daf8fc71220290e5c8375e8ce4be73706c9df35349b7a971e584a3f818b630b6114d8185f64bc8bf683c24a3f598dc"
+        },
+        "imphash": "657e40fb09b2c5e277b865a7cf2b8089",
+        "tlsh": "T18BC633326152303BE6F516F3F94092303D7DA2182B589ABAC6C0DC1D3DA8AD26DF7756",
+        "ssdeep": "196608:vlacAz2ASgg6ra9/fXbCiWIOy/CsDv/EfMZeAXfgbkAZocZdlSwhoxT1C1:daNNS76raXDWIHCsDv0yL8LocvlSx1C1",
+        "trid": [
+          {
+            "type": "file_type",
+            "name": "Windows Control Panel Item",
+            "percentage": 68.8
+          },
+          {
+            "type": "file_type",
+            "name": "Win64 Executable",
+            "percentage": 12.5
+          },
+          {
+            "type": "file_type",
+            "name": "Win16 NE executable",
+            "percentage": 6.0
+          },
+          {
+            "type": "file_type",
+            "name": "Win32 Executable",
+            "percentage": 5.3
+          },
+          {
+            "type": "file_type",
+            "name": "OS/2 Executable",
+            "percentage": 2.4
+          }
+        ]
+      }
+    },
+    {
+      "type": "indicator",
+      "id": "indicator--4f66bca8-9e4b-4beb-3375-8a46fb192b8",
+      "created": "2025-02-14T20:05:11Z",
+      "modified": "2025-02-14T20:34:28Z",
+      "pattern": "[file:hashes.'SHA-256' = '4f66bca89e4beb33758a46fb192b744779052b2e5e2e96e2b41d2fd093f61074']",
+      "pattern_type": "stix",
+      "valid_from": "2025-02-14T20:05:11Z",
+      "labels": ["malicious-activity"],
+      "description": "Indicator for DanaBot malware based on SHA-256 hash."
+    },
+    {
+      "type": "observed-data",
+      "id": "observed-data--4f66bca8-9e4b-4beb-3375-8a46fb192b9",
+      "created": "2025-02-14T20:05:11Z",
+      "modified": "2025-02-14T20:34:28Z",
+      "first_observed": "2025-02-14T20:05:11Z",
+      "last_observed": "2025-02-14T20:34:28Z",
+      "number_observed": 1,
+      "objects": {
+        "0": {
+          "type": "malware",
+          "id": "malware--4f66bca8-9e4b-4beb-3375-8a46fb192b7"
+        }
+      }
+    }
+  ]
+}

--- a/threat_intelligence/stix_edb106cb2a6c45cc815d578514649a6dc894fa9f7415ae1d8032409e8f1f7e2f.json
+++ b/threat_intelligence/stix_edb106cb2a6c45cc815d578514649a6dc894fa9f7415ae1d8032409e8f1f7e2f.json
@@ -1,0 +1,105 @@
+{
+  "type": "bundle",
+  "id": "bundle--b2f9c1f3-5c8e-4c1b-8c5b-1c8f9c1f3e8d",
+  "objects": [
+    {
+      "type": "malware",
+      "id": "malware--edb106cb2a6c45cc815d578514649a6dc894fa9f7415ae1d8032409e8f1f7e2f",
+      "created": "2025-02-14T20:34:32Z",
+      "modified": "2025-02-14T20:34:32Z",
+      "name": "SecuriteInfo.com.Adware.Downware.11276.19796.4860",
+      "is_family": false,
+      "malware_types": ["adware"],
+      "first_seen": "2025-02-14T20:34:32Z",
+      "last_seen": null,
+      "file_size": 17688224,
+      "file_type": "exe",
+      "file_mime_type": "application/x-dosexec",
+      "tags": ["Adware.Generic", "exe", "signed"],
+      "code_signature": [
+        {
+          "subject_cn": "Guang Dong Ji Tong Zhi Neng Ke Ji You Xian Gong Si",
+          "issuer_cn": "GlobalSign GCC R45 CodeSigning CA 2020",
+          "algorithm": "sha256WithRSAEncryption",
+          "valid_from": "2023-07-28T04:23:19Z",
+          "valid_to": "2024-09-19T07:30:08Z",
+          "serial_number": "6641c5ea254c0f89d3bb3353",
+          "thumbprint_algorithm": "SHA256",
+          "thumbprint": "123759a472fcbbd3eaca3ef3a1ebc5c2b1a3d9ef056dfa3ce4ec1f76a1548571"
+        }
+      ],
+      "x_malware_hashes": {
+        "sha256": "edb106cb2a6c45cc815d578514649a6dc894fa9f7415ae1d8032409e8f1f7e2f",
+        "sha3_384": "b00c4926b95c6c1e85cb3c1c652fb1bdca227d31154841ddac4c0f37b79280d3eda322dc90ee0e5686d0caa43c259082",
+        "sha1": "438014d7f256a7ea00d75acc132d2b0ca2bbd3c0",
+        "md5": "903797b2de44370daf15dc1e76dcd74c",
+        "imphash": "48aa5c8931746a9655524f67b25a47ef",
+        "tlsh": "T16B0733413B8304BBF40188398E91B6946E6C75F861F3B4250EB4F66EBB7609B7D307A5",
+        "ssdeep": "393216:4VujzXz9LQvzpDIvvdKuOYrRiy+0qweMUb190wHBUbE/jTYu:YunZeDGvd1rQvbHl/Yu"
+      },
+      "x_malware_trid": [
+        {
+          "type": "trid",
+          "name": ".EXE Inno Setup installer",
+          "confidence": 82.2
+        },
+        {
+          "type": "trid",
+          "name": ".EXE Win64 Executable (generic)",
+          "confidence": 8.0
+        },
+        {
+          "type": "trid",
+          "name": ".EXE Win32 Executable (generic)",
+          "confidence": 3.4
+        },
+        {
+          "type": "trid",
+          "name": ".EXE Win16/32 Executable Delphi generic",
+          "confidence": 1.5
+        },
+        {
+          "type": "trid",
+          "name": ".EXE OS/2 Executable (generic)",
+          "confidence": 1.5
+        }
+      ],
+      "x_malware_intelligence": {
+        "downloads": 578,
+        "uploads": 1
+      }
+    },
+    {
+      "type": "indicator",
+      "id": "indicator--edb106cb-2a6c-45cc-815d-578514649a6d",
+      "created": "2025-02-14T20:34:32Z",
+      "modified": "2025-02-14T20:34:32Z",
+      "name": "Malware SHA256 Hash",
+      "pattern": "[file:hashes.'SHA-256' = 'edb106cb2a6c45cc815d578514649a6dc894fa9f7415ae1d8032409e8f1f7e2f']",
+      "pattern_type": "stix",
+      "valid_from": "2025-02-14T20:34:32Z",
+      "labels": ["malicious-activity"],
+      "created_by_ref": "identity--1f2c3d4e-5e6f-7g8h-9i0j-1k2l3m4n5o6p"
+    },
+    {
+      "type": "observed-data",
+      "id": "observed-data--edb106cb-2a6c-45cc-815d-578514649a6d",
+      "created": "2025-02-14T20:34:32Z",
+      "modified": "2025-02-14T20:34:32Z",
+      "first_observed": "2025-02-14T20:34:32Z",
+      "last_observed": "2025-02-14T20:34:32Z",
+      "number_observed": 1,
+      "objects": {
+        "0": {
+          "type": "file",
+          "hashes": {
+            "SHA-256": "edb106cb2a6c45cc815d578514649a6dc894fa9f7415ae1d8032409e8f1f7e2f"
+          },
+          "name": "SecuriteInfo.com.Adware.Downware.11276.19796.4860",
+          "size": 17688224,
+          "mime_type": "application/x-dosexec"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request includes the addition of two new STIX bundles to the `threat_intelligence` directory. These bundles contain detailed information about two different malware samples, DanaBot and SecuriteInfo.com.Adware.Downware.11276.19796.4860. They were generated using the script https://github.com/The-Art-of-Hacking/h4cker/blob/master/threat_intelligence/malware_bazzar_to_stix.py

### New Malware Samples:

* [`threat_intelligence/stix_4f66bca89e4beb33758a46fb192b744779052b2e5e2e96e2b41d2fd093f61074.json`](diffhunk://#diff-4e709d7c18039bdacfe8d8010df23219089b87b79805d0d21f4f85ba885fd513R1-R88): Added a STIX bundle for DanaBot malware, including metadata such as file hashes, architecture, and observed data.
* [`threat_intelligence/stix_edb106cb2a6c45cc815d578514649a6dc894fa9f7415ae1d8032409e8f1f7e2f.json`](diffhunk://#diff-1fa4030dfdd5eb52f77b141a7c78e2879ee15f902d681328014b9a06e181a9d1R1-R105): Added a STIX bundle for SecuriteInfo.com.Adware.Downware.11276.19796.4860, including metadata such as file size, type, and code signature details.