### PR TITLE
Fixing broken link of cybersecurity regulations

### DIFF
--- a/regulations/README.md
+++ b/regulations/README.md
@@ -1,6 +1,6 @@
 # A Set of Resources Related to Cybersecurity Regulations Around the World
 
-- [US Executive Order on Improving the Nation’s Cybersecurity](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)
+- [CISA's Information about the US Executive Order on Improving the Nation’s Cybersecurity](https://www.cisa.gov/topics/cybersecurity-best-practices/executive-order-improving-nations-cybersecurity)
 - [GPT Created by Omar to interact and learn details about the Secure Software Development Framework (SSDF)](https://chat.openai.com/g/g-HMwdSfFQS-secure-software-development-framework-ssdf-agent)
 - [European Union Cyber Resilience Act](https://digital-strategy.ec.europa.eu/en/policies/cyber-resilience-act)
 - [EU CRA Roadmap by Cybersecurity Coallition](EU_CRA_ROADMAP.pdf)


### PR DESCRIPTION
This pull request includes a small change to the `regulations/README.md` file. The change updates the link for the US Executive Order on Improving the Nation’s Cybersecurity to a more relevant and detailed source.

* [`regulations/README.md`](diffhunk://#diff-6cd99d5a341702237385e7c3d49562a0d9baf157c0610617459153dda3629787L3-R3): Updated the link for the US Executive Order on Improving the Nation’s Cybersecurity to point to CISA's information page.

Fixes #275 