### PR TITLE
Fixed Minor Error

### DIFF
--- a/who-and-what-to-follow/README.md
+++ b/who-and-what-to-follow/README.md
@@ -88,7 +88,7 @@
 - [STÖK](https://www.youtube.com/channel/UCQN2DsjnYH60SFBIA6IkNwg)
 - [The Art of Hacking](https://www.youtube.com/theartofhacking)
 - [The Cyber Mentor](https://www.youtube.com/channel/UC0ArlFuFYMpEewyRBzdLHiw)
-- [David Bombal}(https://www.youtube.com/@davidbombal)
+- [David Bombal](https://www.youtube.com/@davidbombal)
 
 ## Twitch
 - [Red Team Village](https://twitch.tv/redteamvillage)


### PR DESCRIPTION
Simply replaced a misplaced "}" with the appropriate "]" in a markdown link.