### PR TITLE
Update virtual_adapters.md

### DIFF
--- a/wireless_resources/virtual_adapters.md
+++ b/wireless_resources/virtual_adapters.md
@@ -20,7 +20,7 @@ eth0             UP             172.16.217.170/24 fe80::20c:29ff:fe3c:82b0/64
 I am starting the simulator kernel module with the `modprobe mac80211_hwsim` command:
 
 ```
-root@kali:~# modprobe mac80211_hwsim
+root@kali:~# modprobe mac80211_hwsim radios 8
 ```
 
 After starting the module, the wireless interfaces are shown:


### PR DESCRIPTION
This pull request includes a modification to the `wireless_resources/virtual_adapters.md` file to specify the number of radios when starting the `mac80211_hwsim` kernel module.

* [`wireless_resources/virtual_adapters.md`](diffhunk://#diff-668fbb2f2ebc0320680b208d39b90a5dcf4f387ad3997abc4e6bd933dbfcedd5L23-R23): Updated the `modprobe mac80211_hwsim` command to include the `radios 8` parameter, which specifies the number of radios to be created.