### PR TITLE
Create docker-compose.yml

### DIFF
--- a/build_your_own_lab/websploit/docker-compose.yml
+++ b/build_your_own_lab/websploit/docker-compose.yml
@@ -1,0 +1,166 @@
+version: "3.9"
+services:
+
+    webgoat:
+        container_name: "webgoat"
+        image: santosomar/webgoat
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.11
+                
+    juice-shop:
+        container_name: "juice-shop"
+        image: santosomar/juice-shop
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.12
+                
+    dvwa:
+        container_name: "dvwa"
+        image: santosomar/dvwa
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.13
+
+
+    mutillidae_2:
+        container_name: "mutillidae_2"
+        image: santosomar/mutillidae_2
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.14
+
+    dvna:
+        container_name: "dvna"
+        image: santosomar/dvna
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.15
+
+    hackazon:
+        container_name: "hackazon"
+        image: santosomar/hackazon
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.16
+
+    hackme-rtov:
+        container_name: "hackme-rtov"
+        image: santosomar/hackme-rtov
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.17
+
+    mayhem:
+        container_name: "mayhem"
+        image: santosomar/mayhem
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.18
+
+    rtv-safemode:
+        container_name: "rtv-safemode"
+        image: santosomar/rtv-safemode
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.19
+
+    galactic-archives:
+        container_name: "galactic-archives"
+        image: santosomar/galactic-archives
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.20
+
+    yascon-hackme:
+        container_name: "yascon-hackme"
+        image: santosomar/yascon-hackme
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.21
+
+   
+    secretcorp-branch1:
+        container_name: "secretcorp-branch1"
+        image: santosomar/secretcorp-branch1
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.22
+    
+    
+    gravemind:
+        container_name: "gravemind"
+        image: santosomar/gravemind
+        restart: unless-stopped
+        networks:
+            websploit:
+                ipv4_address: 10.6.6.23
+
+    dc30_01:
+      container_name: "dc30_01"
+      image: santosomar/dc30_01:latest
+      restart: unless-stopped
+      networks:
+            websploit:
+                ipv4_address: 10.6.6.24
+
+    dc30_02:
+      container_name: "dc30_02"
+      image: santosomar/dc30_02:latest
+      restart: unless-stopped
+      networks:
+            websploit:
+                ipv4_address: 10.6.6.25
+
+    Y-wing:
+      container_name: "Y-wing"
+      image: santosomar/ywing:latest
+      restart: unless-stopped
+      networks:
+            websploit:
+                ipv4_address: 10.6.6.26
+
+# Containers in the second network for DEF CON 31
+# removed dc31_02 because of a bug that causes the entire virtual disk to be consumed unnecessarily
+    dc31_01:
+      container_name: "dc31_01"
+      image: santosomar/dc31_01:latest
+      restart: unless-stopped
+      networks:
+            websploit2:
+                ipv4_address: 10.7.7.21
+
+    dc31_03:
+        container_name: "dc31_03"
+        image: santosomar/dc31_03:latest
+        restart: unless-stopped
+        networks:
+                websploit2:
+                    ipv4_address: 10.7.7.23
+
+# network configuration
+networks:
+    websploit:
+        driver: bridge
+        ipam:
+            config:
+                - subnet: 10.6.6.0/24
+                  gateway: 10.6.6.1
+    websploit2:
+        driver: bridge
+        ipam:
+            config:
+                - subnet: 10.7.7.0/24
+                  gateway: 10.7.7.1


### PR DESCRIPTION
This pull request introduces a new `docker-compose.yml` file to set up a lab environment with multiple vulnerable web applications and services for security testing. The configuration includes 20 containers across two networks, with custom IP addresses and network settings. Additionally, one container (`dc31_02`) was intentionally omitted due to a known bug.

### New services added:

* **Primary network (`websploit`) services:**
  - Added 17 containers, including `webgoat`, `juice-shop`, `dvwa`, `mutillidae_2`, `dvna`, and others, each configured with specific images and static IP addresses.

* **Secondary network (`websploit2`) services:**
  - Added 2 containers (`dc31_01` and `dc31_03`) for DEF CON 31, configured with static IPs and a separate subnet.

### Network configuration:

* Defined two custom bridge networks (`websploit` and `websploit2`) with unique subnets and gateways for container isolation and organization.

### Known issue addressed:

* Excluded the `dc31_02` container due to a bug causing excessive virtual disk usage.