### PR TITLE
Update ai_security_tools.md

### DIFF
--- a/ai_research/ai_security_tools.md
+++ b/ai_research/ai_security_tools.md
@@ -40,13 +40,12 @@ _Products that intercept prompts and responses and apply security or privacy rul
 - [Skyflow LLM Privacy Vault](https://www.skyflow.com/product/llm-privacy-vault) - Redacts PII from prompts flowing to LLMs.
 - [Guardrails AI](https://www.guardrailsai.com) - Guardrails runs Input/Output Guards in your application that detect, quantify and mitigate the presence of specific types of risks. [![code](https://img.shields.io/github/license/guardrails-ai/guardrails)](https://github.com/guardrails-ai/guardrails/)
 
-## OWASP AI Red Teaming and Security Testing Resources
+## AI Red Teaming Guidance
 - [OWASP's GenAI Red Teaming Guide](https://genaisecurityproject.com/resource/genai-red-teaming-guide/) - guide includes four areas: model evaluation, implementation testing, infrastructure assessment, and runtime behavior analysis.
 - [OWASP's List of AI Security Tools](https://owaspai.org/docs/5_testing/#open-source-tools-for-predictive-ai-red-teaming)
+- [Guidance from the OWASP Generative AI Security Project](https://genai.owasp.org/initiatives/#ai-redteaming)
+- [Guidance from CSA](https://cloudsecurityalliance.org/artifacts/agentic-ai-red-teaming-guide)
 
 ## AI Red Teaming Datasets
 - [AttaQ Dataset](https://huggingface.co/datasets/ibm/AttaQ) - a red teaming dataset consisting of 1402 carefully crafted adversarial questions
-
-## AI Red Teaming Guidance
-- [OWASP AI Testing Guidance](https://owaspai.org/docs/5_testing/)
 - [HarmBench: A Standardized Evaluation Framework for Automated Red Teaming and Robust Refusal](https://arxiv.org/pdf/2402.04249)


### PR DESCRIPTION
This pull request updates the `ai_research/ai_security_tools.md` file to revise and expand sections related to AI red teaming guidance and resources. The changes improve the organization and add new references to external guidance documents.

### Updates to AI Red Teaming Guidance:

* Renamed the section from "OWASP AI Red Teaming and Security Testing Resources" to "AI Red Teaming Guidance" for broader applicability.
* Added two new references:
  - Guidance from the OWASP Generative AI Security Project.
  - Guidance from the Cloud Security Alliance (CSA) Agentic AI Red Teaming Guide.

### Organizational Changes:

* Removed redundant references under "AI Red Teaming Guidance" to streamline the section.

Fixes #310