### PR TITLE
Create langchain-vs-llamaindex.md

### DIFF
--- a/ai_research/LangChain/langchain-vs-llamaindex.md
+++ b/ai_research/LangChain/langchain-vs-llamaindex.md
@@ -1,0 +1,39 @@
+# LangChain vs LlamaIndex
+Both LangChain and LlamaIndex emerged as leading solutions, aiming to abstract away much of the boilerplate code and provide structured ways to interact with LLMs and external data.
+
+They share the overarching goal of making LLM application development easier, but they often approach it with different primary focuses, leading to distinct strengths and ideal use cases.
+
+---
+
+## Introducing LlamaIndex
+
+**LlamaIndex (formerly GPT Index) is a data framework for LLM applications, primarily focused on making it easy to ingest, structure, and retrieve data for use with LLMs.** Its core strength lies in its robust capabilities for connecting LLMs to custom data sources, making it a powerful tool for Retrieval Augmented Generation (RAG).
+
+
+### Key Features and Strengths of LlamaIndex:
+
+* **Data Ingestion & Indexing**: LlamaIndex provides a wide array of `Readers` to load data from various sources (PDFs, Notion, Google Docs, databases, etc.). Its `Indexes` are optimized for storing and querying this data, particularly for RAG.
+* **Querying and Retrieval**: It excels at transforming user queries into effective retrieval operations over your indexed data. It offers various `Query Engines` and `Retrievers` tailored for different data structures and retrieval strategies (e.g., semantic search, keyword search, hybrid search).
+* **Structured Data Integration**: Beyond unstructured text, LlamaIndex has strong capabilities for working with semi-structured and structured data, such as tables, knowledge graphs, and relational databases.
+* **Performance Optimization**: LlamaIndex focuses on optimizing the RAG pipeline for performance, especially for large datasets.
+* **Context Augmentation**: Its primary goal is to provide the most relevant context to the LLM, enhancing its ability to answer questions grounded in your data.
+* **Emphasis on Data Loading and Indexing**: If your primary challenge is efficiently loading and indexing vast amounts of complex, unstructured, or semi-structured data for RAG, LlamaIndex is often the go-to choice.
+
+---
+
+## LangChain vs. LlamaIndex: A Comparison
+
+While there's significant overlap and they are often used together, let's highlight their core differences and when each might be preferred.
+
+| Feature / Aspect       | LangChain                                             | LlamaIndex                                             |
+| :--------------------- | :---------------------------------------------------- | :----------------------------------------------------- |
+| **Primary Focus** | **LLM Orchestration, Agentic Workflows** | **Data Indexing, Retrieval, and RAG Optimization** |
+| **Core Strength** | Chains, Agents, Tool use, Conversational memory       | Data loaders, Indexing structures, Query engines       |
+| **Data Handling** | Provides data loading and splitting, integrates with vector stores (as part of a chain) | **Deep focus on data ingestion, indexing, and retrieval optimization** |
+| **Tool Usage** | **Native, robust agent tooling capabilities** | Less emphasis on agentic tool usage beyond data retrieval |
+| **Agentic Focus** | **Strong emphasis on autonomous agents, planning, reflection** | Less emphasis on multi-step agentic behavior beyond RAG |
+| **Chains/Flows** | Comprehensive `Chain` abstractions for complex multi-step processes | `Query Engines` are focused on data retrieval and synthesis |
+| **Memory Management** | Rich set of built-in memory types for conversations    | Focuses more on memory *within* the data retrieval process (e.g., query history for refinement) |
+| **Integrations** | Wide array of LLM, tool, vector store integrations     | Extensive data source integrations, good LLM/vector store integrations |
+| **When to Use** | Building conversational agents, multi-step agents, complex workflows, custom tool invocation | When your primary challenge is connecting LLMs to *your specific data*, building highly optimized RAG pipelines, or dealing with diverse data formats |
+


### PR DESCRIPTION
This pull request adds a new documentation file comparing LangChain and LlamaIndex, two frameworks for developing applications with large language models (LLMs). The document highlights their differences, strengths, and ideal use cases, providing a structured guide for developers to choose the right tool for their needs.

### Documentation Update:

* Added `langchain-vs-llamaindex.md` in the `ai_research/LangChain` directory, detailing the comparison between LangChain and LlamaIndex. The document covers their primary focuses, key features, and a side-by-side comparison table to help developers understand when to use each framework.