### PR TITLE
fix PuTTY link in README.md

### DIFF
--- a/networking/README.md
+++ b/networking/README.md
@@ -81,7 +81,7 @@ by James Forshaw.
 ### Remote access and sharing tools
 
 * [Remmina](https://remmina.org/) - An open source remote access tool. It supports RDP, SSH, VNC, and other protocols for remote access.
-* [PuTTY](https://www.putty.org/) - One of the most popular SSH and Telnet clients for Windows.
+* [PuTTY](https://putty.software/) - One of the most popular SSH and Telnet clients for Windows.
 * [FileZilla](https://filezilla-project.org/) - An open source tool for file transfer. Support FTP, FTPS and SFTP protocols.
 * [WinSCP](https://winscp.net/eng/index.php) - A popular SFTP client and FTP client for Windows.
 * [SecureCRT](https://www.vandyke.com/products/securecrt/) - A commercial SSH and Telnet client and terminal emulator by VanDyke Software.


### PR DESCRIPTION
The link to PuTTY was pointing to putty.org. This domain has no relation to the PuTTY project! Instead, the website run by the actual PuTTY team can be found under https://putty.software , see https://hachyderm.io/@simontatham/115025974777386803