### PR TITLE
feature/Update crypto_algorithms.md

### DIFF
--- a/crypto/crypto_algorithms.md
+++ b/crypto/crypto_algorithms.md
@@ -1,49 +1,73 @@
-# Cryptographic Algorithms
-Let's go over the most common encryption and hashing algorithms, and compare them.
+# Cryptographic Algorithms (2025 Edition)
 
-Based on the search results and NIST's announcements, here is the status of cryptographic standards and their quantum resistance:
+This section summarizes current and emerging cryptographic standards, their quantum resistance, and migration guidance for modern security.
 
 ## Current Standards
 
-**Public Key Encryption & Key Exchange**
-| Algorithm | Status | Post-Quantum Ready |
-|-----------|---------|-------------------|
-| RSA | Active but vulnerable | No |
-| ECC/ECDSA | Active but vulnerable | No |
-| ML-KEM (CRYSTALS-Kyber) | Approved | Yes |
+### Public Key Encryption & Key Exchange
 
-**Digital Signatures**
-| Algorithm | Status | Post-Quantum Ready |
-|-----------|---------|-------------------|
-| RSA Signatures | Active but vulnerable | No |
-| ECDSA | Active but vulnerable | No |
-| SLH-DSA (SPHINCS+) | Approved | Yes |
+| Algorithm           | Status                    | Post-Quantum Ready |
+|---------------------|---------------------------|--------------------|
+| RSA                 | Deprecated: quantum-vulnerable | No                |
+| ECC/ECDSA           | Deprecated: quantum-vulnerable | No                |
+| Diffie-Hellman      | Deprecated: quantum-vulnerable | No                |
+| ML-KEM (CRYSTALS-Kyber) | Approved (FIPS 203)    | Yes               |
+| HQC (Hamming Quasi-Cyclic) | Selected (2025)      | Yes               |
 
-## Future Standards
+### Digital Signatures
 
-**Additional Post-Quantum Algorithms**
-| Algorithm | Status | Type |
-|-----------|---------|------|
-| FIPS 204 (Dilithium) | In development | Digital Signature |
-| FIPS 205 (SPHINCS+) | In development | Digital Signature |
-| FALCON | Selected | Digital Signature |
+| Algorithm           | Status                    | Post-Quantum Ready |
+|---------------------|--------------------------|--------------------|
+| RSA Signatures      | Deprecated: quantum-vulnerable | No            |
+| ECDSA, EdDSA, DSA   | Deprecated: quantum-vulnerable | No            |
+| SLH-DSA (SPHINCS+)  | Approved (FIPS 205)      | Yes               |
+| ML-DSA (CRYSTALS-Dilithium) | Approved (FIPS 204) | Yes               |
+| FALCON              | Selected for standardization | Yes            |
+
+***
 
 ## Symmetric Algorithms
-| Algorithm | Status | Post-Quantum Ready | Notes |
-|-----------|---------|-------------------|--------|
-| AES-256 | Active | Yes* | Requires larger key sizes |
-| SHA-2 | Active | Yes* | Requires larger output sizes |
-| SHA-3 | Active | Yes* | Requires larger output sizes |
 
-*Note: Symmetric algorithms are considered quantum-resistant when using sufficiently large key/output sizes, though they may need larger parameters to maintain the same security level against quantum attacks.
+Symmetric crypto is less affected by quantum computers, but key/output sizes must be larger to compensate for Grover’s algorithm.
 
-The transition to post-quantum cryptography represents a major shift in cryptographic standards to protect against future quantum computer threats. You are encouraged to begin planning for migration to these new algorithms while maintaining current standards during the transition period.
+| Algorithm | Status   | Post-Quantum Ready | Notes                                  |
+|-----------|----------|-------------------|----------------------------------------|
+| AES-256   | Active   | Yes*              | Use longer keys (min. 256 bits)        |
+| AES-128   | Avoid    | No                | Insufficient against Grover’s algorithm|
+| SHA-2     | Active   | Yes*              | Use ≥256-bit output, SHA-512 preferred |
+| SHA-1     | Avoid    | No                | Collision-prone, quantum-vulnerable    |
+| SHA-3     | Active   | Yes*              | Use ≥256-bit output                    |
 
+*Symmetric algorithms are quantum-resistant with large enough keys/output sizes, but quantum computers halve the effective security strength. Migrate away from AES-128 and SHA-1.
 
+***
 
+## Algorithms To Avoid (Do Not Use For New Deployments)
+
+- **RSA (encryption/signatures)**
+- **ECC/ECDSA/EdDSA** (incl. Ed25519, Curve25519)
+- **Diffie-Hellman** (including DH key exchanges)
+- **DSA/ElGamal**
+- **SHA-1** (all uses)
+- **AES-128** (upgrade to AES-256)
+- Any legacy protocol not listed in the “Approved” section
+
+These are **deprecated** due to quantum vulnerability. Do not deploy or rely on for long-term data protection.
+
+***
+
+## Migration Guidance
+
+- Start transitioning public-key infrastructure to Kyber, Dilithium, SPHINCS+, and Falcon as finalized by NIST standards (FIPS 203, 204, 205).
+- Use AES-256 for symmetric encryption and SHA-2/SHA-3 (≥256 bits) for hashing.
+- Regularly follow NIST updates: https://csrc.nist.gov/projects/post-quantum-cryptography
+- For transitional environments, hybrid schemes (classical + post-quantum) may be used until the migration is complete.
+
+***
 
 ## Additional References
-Again, I must emphasize that the field of post-quantum cryptography is evolving, and it is recommended to stay updated with the latest research and guidelines from NIST.
-- NIST Post-Quantum Cryptography Project: https://csrc.nist.gov/projects/post-quantum-cryptography
-- Post Quantum Cryptography (Wikipedia): https://en.wikipedia.org/wiki/Post-quantum_cryptography
-- Information Week Podcast: https://www.youtube.com/watch?v=GvkCrSqSn5g
+
+- [NIST Post-Quantum Cryptography Project](https://csrc.nist.gov/projects/post-quantum-cryptography)
+- [Cisco Blog about PQC](https://blogs.cisco.com/developer/how-post-quantum-cryptography-affects-security-and-encryption-algorithms)
+- [Post Quantum Cryptography](https://en.wikipedia.org/wiki/Post-quantum_cryptography) (Wikipedia)
+- [Information Week Podcast](https://www.youtube.com/watch?v=GvkCrSqSn5g)


### PR DESCRIPTION
This pull request updates the `crypto/crypto_algorithms.md` documentation to reflect the latest (2025) guidance on cryptographic algorithms, with a strong focus on post-quantum security. The changes clarify which algorithms are approved, deprecated, or should be avoided, and provide migration recommendations for modern cryptographic standards.

Key updates include:

**Post-Quantum Cryptography Standards and Status**
- Updated tables for public key encryption, key exchange, and digital signatures to reflect the latest NIST-approved and selected post-quantum algorithms (Kyber, Dilithium, SPHINCS+, Falcon, HQC) and clearly mark RSA, ECC, and related algorithms as deprecated due to quantum vulnerabilities.

**Symmetric Cryptography Guidance**
- Expanded guidance on symmetric algorithms, recommending AES-256 and SHA-2/SHA-3 (≥256 bits), and advising against AES-128 and SHA-1 in light of quantum threats.

**Migration and Deployment Recommendations**
- Added a new section listing algorithms to avoid for new deployments, with a clear callout of deprecated algorithms and protocols.
- Provided detailed migration guidance, including recommendations to transition to post-quantum algorithms and use hybrid schemes during the transition period.

**References and Resources**
- Updated and expanded the list of references to include authoritative resources

Fixes #349 