### PR TITLE
Fix prerequisite lab references in README.md

### DIFF
--- a/ai_research/ollama-labs/README.md
+++ b/ai_research/ollama-labs/README.md
@@ -55,7 +55,7 @@ Learn to integrate Ollama into applications using HTTP requests:
 - Building scripts with curl and API calls
 
 **Prerequisites:** 
-- Completed [Labs 1-2](lab-01-installation-and-basics.md) and [Lab 2](lab-02-cli-advanced.md)
+- Completed [Lab 1](lab-01-installation-and-basics.md) and [Lab 2](lab-02-cli-advanced.md)
 - Basic understanding of HTTP and REST APIs
 - Familiarity with [JSON](https://www.json.org/json-en.html)
 


### PR DESCRIPTION
- Fixes #400

This pull request makes a minor correction to the prerequisites section in the Ollama labs documentation. The change clarifies the references to the required labs for integration.

* Documentation update: Changed the prerequisites to reference `[Lab 1]` and `[Lab 2]` individually, instead of `[Labs 1-2]` and `[Lab 2]`, in the `ai_research/ollama-labs/README.md` file.