### PR TITLE
Updating Ollama Labs documentation with corrected link for model variants

### DIFF
--- a/ai-research/ai-research/ollama-labs/README.md
+++ b/ai-research/ai-research/ollama-labs/README.md
@@ -32,7 +32,7 @@ Start your journey by installing [Ollama](https://ollama.com/) and running your 
 **Difficulty:** Beginner to Intermediate
 
 Master the command-line interface with advanced features:
-- Exploring different [model variants and tags](https://ollama.com/docs/tags)
+- Exploring different [model variants and tags](https://ollama.com/search)
 - Working with [embeddings](https://docs.ollama.com/capabilities/embeddings) for semantic similarity
 - Using [vision models](https://docs.ollama.com/capabilities/vision) to analyze images
 - Batch processing and automation


### PR DESCRIPTION
- Fixes #424 
- Updating Ollama Labs documentation with corrected link for model variants

This pull request updates the documentation link in the `README.md` to point users to a more relevant resource for exploring model variants and tags.

Documentation update:

* Updated the link for exploring different model variants and tags from the Ollama documentation to the Ollama model search page in `README.md`.