### PR TITLE
Update virtual_adapters.md with detailed modprobe info

### DIFF
--- a/wireless-resources/virtual_adapters.md
+++ b/wireless-resources/virtual_adapters.md
@@ -51,7 +51,7 @@ hwsim0           DOWN
 
 ### Practical effect
 
-After running `sudo modprobe mac80211_hwsim radios=8`:
+After running `modprobe mac80211_hwsim radios=8`:
 
 - You get 8 virtual Wi‑Fi radios you can see with `iw dev` or `iw phy`.
 - Each can be configured independently (AP, STA, monitor, different channels, etc.), allowing you to build multi‑AP / multi‑STA test topologies entirely in software on a single host.


### PR DESCRIPTION
Clarified the usage of the 'modprobe mac80211_hwsim radios=8' command and detailed the parameters and practical effects of the virtual Wi-Fi radios created.

- Fixes #432 