### PR TITLE
Add NullSec Tools to recon tools

### DIFF
--- a/recon/tools.md
+++ b/recon/tools.md
@@ -213,4 +213,4 @@ This is a curated list of tools for this category.
 - [pwnedOrNot v1.1.7 - OSINT Tool To Find Passwords For Compromised Email Addresses](http://feedproxy.google.com/~r/PentestTools/~3/zMsIKFBaGtY/pwnedornot-v117-osint-tool-to-find.html)
 - [pwnedOrNot v1.2.6 - OSINT Tool to Find Passwords for Compromised Email Addresses](http://feedproxy.google.com/~r/PentestTools/~3/SxvMbSv8GrY/pwnedornot-v126-osint-tool-to-find.html)
 - [shuffleDNS -  Wrapper Around Massdns Written In Go That Allows You To Enumerate Valid Subdomains](http://feedproxy.google.com/~r/PentestTools/~3/rrx6tcXT4Vg/shuffledns-wrapper-around-massdns.html)
-- [NullSec Tools](https://github.com/bad-antics/nullsec-tools) - Professional security toolkit with Python, Go, Rust, and C tools for penetration testing, OSINT, reconnaissance, and network analysis.
+- [NullSec Tools - Security Toolkit With Python, Go, Rust, And C Tools For OSINT And Reconnaissance](https://github.com/bad-antics/nullsec-tools)


### PR DESCRIPTION
## NullSec Tools Recon Addition

Adding [NullSec Tools](https://github.com/bad-antics/nullsec-tools) to the recon tools list.

### Reconnaissance Capabilities:
- �� Subdomain enumeration
- 🌐 DNS reconnaissance
- 📊 Network scanning utilities
- 🔎 Service discovery
- 📧 Email harvesting
- 🕵️ OSINT collection tools

### Multi-language Toolkit:
- Python, Go, Rust, C implementations

All tools are open source and designed for legitimate security research and penetration testing.

**Repository:** https://github.com/bad-antics/nullsec-tools