### PR TITLE
Add Phantom zero-knowledge proof framework

### DIFF
--- a/cryptography-and-pki/crypto_frameworks.md
+++ b/cryptography-and-pki/crypto_frameworks.md
@@ -158,6 +158,7 @@ algorithm.
 - [Nettle.jl](https://github.com/staticfloat/Nettle.jl) - Julia wrapper around nettle cryptographic hashing/
 encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as well as AES encryption/decryption.
 - [SHA.jl](https://github.com/staticfloat/SHA.jl) - Performant, 100% native-julia SHA1, SHA2-{224,256,384,512} implementation.
+- [Phantom](https://github.com/bad-antics/phantom) - Zero-knowledge proof framework for anonymous vulnerability disclosure implementing zk-SNARKs for privacy-preserving security reporting.
 
 ### Lua
 
@@ -236,7 +237,3 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 - [Swift-Sodium](https://github.com/jedisct1/swift-sodium) - Swift interface to the Sodium library for common crypto operations for iOS and macOS.
 - [SwiftSSL](https://github.com/SwiftP2P/SwiftSSL) - Elegant crypto toolkit in Swift.
 - [SwiftThemis](https://github.com/cossacklabs/themis/wiki/Swift-Howto) - Swift wrapper on Themis for iOS and macOS. High level crypto library for storing data (AES), secure messaging (ECC + ECDSA / RSA + PSS + PKCS#7) and session-oriented, forward secrecy data exchange (ECDH key agreement, ECC & AES encryption).
-
-### Julia Zero-Knowledge Frameworks
-
-- **[Phantom](https://github.com/bad-antics/phantom)** - Zero-knowledge proof framework for anonymous vulnerability disclosure in Julia. Implements zk-SNARKs for privacy-preserving security reporting without revealing researcher identity. 6,302 lines of Julia code.


### PR DESCRIPTION
## Phantom - Zero-Knowledge Proofs for Anonymous Disclosure

Phantom is a ZK-proof framework written in Julia:

- **zk-SNARKs Implementation** for privacy-preserving proofs
- **Anonymous Vulnerability Disclosure** without revealing researcher identity
- **Cryptographic Verification** of security findings
- **Privacy-First Design** for responsible disclosure

### Details
- **Language**: Julia (6,302 lines)
- **License**: MIT
- **Use Case**: Anonymous bug bounty submissions and responsible disclosure

This adds Phantom to the cryptography frameworks section as a Julia-based ZK-proof system.