### PR TITLE
Grant write permissions for contents in PR workflow

### DIFF
--- a/.github/workflows/assign_pr.yml
+++ b/.github/workflows/assign_pr.yml
@@ -14,6 +14,8 @@ jobs:
 
     permissions:
       pull-requests: write
+      contents: write
+  
 
     steps:
     - name: Assign pull request


### PR DESCRIPTION
Updated workflow to allow write access to contents for PR assignments.

This pull request introduces a minor update to the GitHub Actions workflow configuration by adjusting permissions. Specifically, it grants write access to repository contents in addition to pull request permissions.

- Workflow permissions: Added `contents: write` to the permissions block in `.github/workflows/assign_pr.yml` to allow the workflow to write to repository contents.