### PR TITLE
Add NSA/CISA guidance link for LOTL attacks

### DIFF
--- a/post-exploitation/README.md
+++ b/post-exploitation/README.md
@@ -50,6 +50,7 @@
 ## Living Off The Land, Bins, and Useful Scripts
 * [GTFO Bins](https://gtfobins.github.io/)
 * [LOLBAS](https://github.com/LOLBAS-Project/LOLBAS)
+* [NSA/CISA Guidance to Mitigate Living Off The Land Attacks](https://media.defense.gov/2024/Feb/07/2003389936/-1/-1/0/JOINT-GUIDANCE-IDENTIFYING-AND-MITIGATING-LOTL.PDF)
 
 ## Command and Control
 * [C2 Matrix](https://www.thec2matrix.com/)


### PR DESCRIPTION
This pull request makes a small update to the `post-exploitation/README.md` file, adding a new resource link for mitigating "Living Off The Land" attacks.

* Added a link to the NSA/CISA guidance document for identifying and mitigating Living Off The Land (LOTL) attacks under the "Living Off The Land, Bins, and Useful Scripts" section.