### PR TITLE
Add ReleaseRun Kubernetes release-tracking resource

### DIFF
--- a/SCOR/kubernetes.md
+++ b/SCOR/kubernetes.md
@@ -16,6 +16,7 @@
 * [The ‘kubectl run’ command](http://medium.com/@mhausenblas/the-kubectl-run-command-27c68de5cb76#.mlwi5an7o) by [Michael Hausenblas](https://twitter.com/mhausenblas)
 * [Docker Kubernetes Lab Handbook](https://github.com/xiaopeng163/docker-k8s-lab) by [Peng Xiao](https://twitter.com/xiaopeng163)
 * [Curated Resources for Kubernetes](https://hackr.io/tutorials/learn-kubernetes)
+* [ReleaseRun Kubernetes Releases](https://releaserun.com/kubernetes-releases/) - Track supported Kubernetes versions, release timelines, end-of-life dates, and upgrade notes in one place.
 * [Kubernetes Comic](https://cloud.google.com/kubernetes-engine/kubernetes-comic/) by [Google Cloud Platform](https://cloud.google.com/)
 * [Kubernetes 101: Pods, Nodes, Containers, and Clusters](https://medium.com/google-cloud/kubernetes-101-pods-nodes-containers-and-clusters-c1509e409e16) by [Dan Sanche](https://medium.com/@sanche)
 * [An Introduction to Kubernetes](http://www.digitalocean.com/community/tutorials/an-introduction-to-kubernetes) by [Justin Ellingwood](https://twitter.com/jmellingwood)


### PR DESCRIPTION
Adds a Kubernetes release-tracking resource with supported versions, EOL timelines, and upgrade notes.

**URL:** https://releaserun.com/kubernetes-releases/

Useful for engineers tracking which Kubernetes versions are still supported, when EOL dates land, and what to watch for when planning upgrades.