### PR TITLE
Add HTB Writeups to CTF resources

### DIFF
--- a/capture-the-flag/README.md
+++ b/capture-the-flag/README.md
@@ -5,6 +5,7 @@ Capture the flag (CTF) is a computer security competition that is designed for e
 * https://github.com/apsdehal/awesome-ctf
 
 ## Some others:
+* https://github.com/momenbasel/htb-writeups - Comprehensive Hack The Box writeup collection covering 500+ machines, 400+ challenges, ProLabs, Sherlocks, CTF events, and certification prep
 * https://trailofbits.github.io/ctf/
 * https://ctftime.org
 * https://ctf365.com


### PR DESCRIPTION
## Summary
- Adds [HTB Writeups](https://github.com/momenbasel/htb-writeups) to the Capture The Flag resources list
- A comprehensive Hack The Box writeup collection covering 500+ machines, 400+ challenges, ProLabs, Sherlocks (DFIR), CTF events, and certification prep (OSCP/CPTS)
- Structured and searchable index organized by difficulty, OS, technique, and certification relevance

## Changes
- `capture-the-flag/README.md`: Added one bullet entry under "Some others" section