### PR TITLE
Add HackMyIP to Networking tools

### DIFF
--- a/networking/tools.md
+++ b/networking/tools.md
@@ -43,6 +43,7 @@ This is a curated list of tools for this category.
 - [Goscan - Interactive Network Scanner](http://feedproxy.google.com/~r/PentestTools/~3/QvZdo-L3mC8/goscan-interactive-network-scanner.html)
 - [Goscan - Interactive Network Scanner](http://feedproxy.google.com/~r/PentestTools/~3/uz1Ra9_76sE/goscan-interactive-network-scanner.html)
 - [HSTP - Simple Hyper Service Transfer Protocol On Networks](http://www.kitploit.com/2022/10/hstp-simple-hyper-service-transfer.html)
+- [HackMyIP - Free Privacy And Security Toolkit With 19+ Network Tools Including IP Lookup, DNS Leak Test, WebRTC Leak Test, Port Scanner, And More](https://hackmyip.com/)
 - [HoneyBot - Capture, Upload And Analyze Network Traffic](http://feedproxy.google.com/~r/PentestTools/~3/fuF8npyiVbc/honeybot-capture-upload-and-analyze.html)
 - [HoneyCreds - Network Credential Injection To Detect Responder And Other Network Poisoners](http://feedproxy.google.com/~r/PentestTools/~3/Huw9_NtLQX8/honeycreds-network-credential-injection.html)
 - [Hyenae-Ng - An Advanced Cross-Platform Network Packet Generator And The Successor Of Hyenae](http://www.kitploit.com/2021/11/hyenae-ng-advanced-cross-platform.html)


### PR DESCRIPTION
## Description

Adding [HackMyIP](https://hackmyip.com/) to the Networking tools list (`networking/tools.md`).

HackMyIP is a free online privacy and security toolkit offering 19+ networking-related tools including:
- IP address lookup & geolocation
- DNS lookup
- DNS leak test
- WebRTC leak test
- Port scanner
- Speed test
- Browser fingerprint analysis
- Email breach checker
- Password strength checker & generator

All tools are completely free with no registration or API key required.