### PR TITLE
Create repository taxonomy skeleton

### DIFF
--- a/ai/ai-security/README.md
+++ b/ai/ai-security/README.md
@@ -1,0 +1,16 @@
+# AI Security
+
+Resources in this track:
+
+- [ai-algorithmic-red-teaming](ai-algorithmic-red-teaming/)
+- [ai-risk-management](ai-risk-management/)
+- [ai-security-overview.md](ai-security-overview.md)
+- [ai_risk_management](ai_risk_management/)
+- [ai_security_tools.md](ai_security_tools.md)
+- [ai_security_tools_root.md](ai_security_tools_root.md)
+- [Coalition-for-Secure-AI-CoSAI-Risk-Map.md](Coalition-for-Secure-AI-CoSAI-Risk-Map.md)
+- [MCP-Security](MCP-Security/)
+- [model_and_genai_application_security_testing.md](model_and_genai_application_security_testing.md)
+- [model_security_testing.md](model_security_testing.md)
+- [prompt-injection](prompt-injection/)
+- [tools.md](tools.md)

--- a/ai/ethics-privacy-governance/README.md
+++ b/ai/ethics-privacy-governance/README.md
@@ -1,0 +1,5 @@
+# Ethics, Privacy, and Governance
+
+Resources in this track:
+
+- [ethics_privacy](ethics_privacy/)

--- a/ai/incident-response-and-automation/README.md
+++ b/ai/incident-response-and-automation/README.md
@@ -1,0 +1,12 @@
+# Incident Response and Automation
+
+Resources in this track:
+
+- [ai-for-incident-response](ai-for-incident-response/)
+- [ai_coding_tools.md](ai_coding_tools.md)
+- [labs](labs/)
+- [monitoring-basic.md](monitoring-basic.md)
+- [monitoring.md](monitoring.md)
+- [open-interpreter-examples](open-interpreter-examples/)
+- [presos](presos/)
+- [training-environment-security](training-environment-security/)

--- a/ai/llm-engineering/README.md
+++ b/ai/llm-engineering/README.md
@@ -1,0 +1,16 @@
+# LLM Engineering
+
+Resources in this track:
+
+- [ai_agentic_tools_for_cybersecurity.md](ai_agentic_tools_for_cybersecurity.md)
+- [datasets.rst](datasets.rst)
+- [fine-tuning](fine-tuning/)
+- [GPTs](GPTs/)
+- [LangChain](LangChain/)
+- [LLM-frameworks](LLM-frameworks/)
+- [ML-Fundamentals](ML-Fundamentals/)
+- [ollama-labs](ollama-labs/)
+- [prompt-engineering](prompt-engineering/)
+- [prompt_engineering.md](prompt_engineering.md)
+- [RAG](RAG/)
+- [vector-databases](vector-databases/)

--- a/certifications/cisco/README.md
+++ b/certifications/cisco/README.md
@@ -1,0 +1,4 @@
+# Cisco Certifications
+
+- [SCOR 350-701](scor-350-701/) - supplemental material for Cisco Security Core technologies and CCNP/CCIE Security preparation.
+- [Cisco Certifications](https://www.cisco.com/c/en/us/training-events/training-certifications/certifications.html)

--- a/certifications/cloud/README.md
+++ b/certifications/cloud/README.md
@@ -1,0 +1,11 @@
+# Cloud Certifications
+
+- [AWS Certified Security Specialty](https://aws.amazon.com/certification/certified-security-specialty/)
+- [Azure Security Engineer Associate](https://docs.microsoft.com/en-us/learn/certifications/azure-security-engineer/)
+- [Professional Cloud Security Engineer](https://cloud.google.com/certification/cloud-security-engineer)
+- [Oracle Cloud Infrastructure Security Professional](https://education.oracle.com/oracle-cloud-infrastructure-security-professional/pexam_1Z0-1104-23)
+- [CCSP - Certified Cloud Security Professional](https://www.isc2.org/Certifications/CCSP)
+- [CCSK - Certificate of Cloud Security Knowledge](https://cloudsecurityalliance.org/education/ccsk/)
+- [CCAK - Certificate of Cloud Auditing Knowledge](https://cloudsecurityalliance.org/education/ccak/)
+
+Related domain resources: [Cloud and Container Security](../../cybersecurity-domains/cloud-container-security/).

--- a/certifications/comptia/README.md
+++ b/certifications/comptia/README.md
@@ -1,0 +1,6 @@
+# CompTIA Certifications
+
+- [CompTIA PenTest+ PT0-002 Cert Guide](https://learning.oreilly.com/library/view/comptia-pentest-pt0-002/9780137566204/)
+- Defensive training resources in this repository also reference Security+, CySA+, and CASP+ preparation.
+
+Related domain resources: [Defensive Security](../../cybersecurity-domains/defensive-security/) and [Offensive Security](../../cybersecurity-domains/offensive-security/).

--- a/certifications/isc2/README.md
+++ b/certifications/isc2/README.md
@@ -1,0 +1,7 @@
+# ISC2 Certifications
+
+- [Certified in Cybersecurity - CC](https://learning.oreilly.com/course/certified-in-cybersecurity/9780138230364/)
+- [CISSP](https://www.isc2.org/Certifications/CISSP)
+- [CCSP](https://www.isc2.org/Certifications/CCSP)
+
+Related domain resources: [Fundamentals](../../cybersecurity-domains/fundamentals/) and [Cloud and Container Security](../../cybersecurity-domains/cloud-container-security/).

--- a/certifications/kubernetes-cncf/README.md
+++ b/certifications/kubernetes-cncf/README.md
@@ -1,0 +1,10 @@
+# Kubernetes and CNCF Certifications
+
+- [CKAD](https://www.cncf.io/certification/ckad/)
+- [CKA](https://www.cncf.io/certification/cka/)
+- [CKS](https://www.cncf.io/certification/cks/)
+- [Certified Kubernetes Administrator Course](https://github.com/kodekloudhub/certified-kubernetes-administrator-course)
+- [Certified Kubernetes Security Specialist](https://github.com/walidshaari/Certified-Kubernetes-Security-Specialist)
+- [Kubernetes Security Specialist Study Guide](https://github.com/stackrox/Kubernetes_Security_Specialist_Study_Guide)
+
+Related domain resources: [Docker and Kubernetes Security](../../cybersecurity-domains/cloud-container-security/docker-and-k8s-security/).

--- a/certifications/offensive-security/README.md
+++ b/certifications/offensive-security/README.md
@@ -1,0 +1,7 @@
+# Offensive Security Certifications
+
+- [Certified Ethical Hacker (CEH), Latest Edition](https://learning.oreilly.com/course/certified-ethical-hacker/9780135395646/)
+- [CEH Certified Ethical Hacker Cert Guide](https://learning.oreilly.com/library/view/ceh-certified-ethical/9780137489930/)
+- [The Art of Hacking](https://theartofhacking.org) - helpful preparation for OSCP and CEH topics.
+
+Related domain resources: [Offensive Security](../../cybersecurity-domains/offensive-security/).

--- a/certifications/roadmaps/README.md
+++ b/certifications/roadmaps/README.md
@@ -1,0 +1,5 @@
+# Certification Roadmaps
+
+- [Cybersecurity Certifications Lists](cybersec_certifications.md)
+- [Interactive Cybersecurity Certifications Roadmap](https://certs.hacker26.com)
+- [Paul Jerimy Security Certification Roadmap](https://pauljerimy.com/security-certification-roadmap/)

--- a/cybersecurity-domains/README.md
+++ b/cybersecurity-domains/README.md
@@ -1,0 +1,14 @@
+# Cybersecurity Domains
+
+Resources in this section are organized by cybersecurity domain.
+
+- [Fundamentals](fundamentals/) - foundational concepts, methodology, and general learning paths.
+- [Offensive Security](offensive-security/) - reconnaissance, exploitation, payloads, post-exploitation, bug bounty, fuzzing, reverse engineering, and adversarial emulation.
+- [Defensive Security](defensive-security/) - DFIR, threat hunting, threat intelligence, honeypots, hardening, endpoint security, and SBOM resources.
+- [Application Security](application-security/) - web application testing, DevSecOps, secure coding, API security, and scripting for security automation.
+- [Cloud and Container Security](cloud-container-security/) - cloud provider security, Docker, Kubernetes, and container security resources.
+- [Infrastructure and Network Security](infrastructure-network-security/) - networking, wireless, VIRL topologies, and packet capture resources.
+- [Cryptography and PKI](cryptography-pki/) - cryptography, PKI, TLS, labs, tutorials, and challenges.
+- [Hardware and Embedded Security](hardware-embedded-security/) - IoT, car hacking, mobile security, and game hacking.
+- [Governance, Risk, and Compliance](governance-risk-compliance/) - regulations, policy, compliance, and program governance resources.
+- [Labs and Practice](labs-practice/) - vulnerable servers, CTFs, reports, and practice artifacts. Lab-building content remains at [build-your-own-lab](../build-your-own-lab/).

--- a/cybersecurity-domains/application-security/README.md
+++ b/cybersecurity-domains/application-security/README.md
@@ -1,0 +1,8 @@
+# Application Security
+
+Resources in this domain:
+
+- [Web Application Testing](web-application-testing/)
+- [DevSecOps](devsecops/)
+- [Programming and Scripting for Cybersecurity](programming-and-scripting-for-cybersecurity/)
+- [Python, Ruby, and Bash](python-ruby-and-bash/)

--- a/cybersecurity-domains/cloud-container-security/README.md
+++ b/cybersecurity-domains/cloud-container-security/README.md
@@ -1,0 +1,6 @@
+# Cloud and Container Security
+
+Resources in this domain:
+
+- [Cloud Resources](cloud-resources/)
+- [Docker and Kubernetes Security](docker-and-k8s-security/)

--- a/cybersecurity-domains/cryptography-pki/README.md
+++ b/cybersecurity-domains/cryptography-pki/README.md
@@ -1,0 +1,5 @@
+# Cryptography and PKI
+
+Resources in this domain:
+
+- [Cryptography and PKI](cryptography-and-pki/)

--- a/cybersecurity-domains/defensive-security/README.md
+++ b/cybersecurity-domains/defensive-security/README.md
@@ -1,0 +1,13 @@
+# Defensive Security
+
+Resources in this domain:
+
+- [DFIR](dfir/)
+- [Threat Hunting](threat-hunting/)
+- [Threat Intelligence](threat-intelligence/)
+- [Dark Web Research](darkweb-research/)
+- [Honeypots and Honeynets](honeypots-honeynets/)
+- [Linux Hardening](linux-hardening/)
+- [macOS Hardening](macos-hardening/)
+- [Windows Security](windows/)
+- [SBOM](sbom/)

--- a/cybersecurity-domains/fundamentals/README.md
+++ b/cybersecurity-domains/fundamentals/README.md
@@ -1,0 +1,6 @@
+# Fundamentals
+
+Resources in this domain:
+
+- [Foundational Cybersecurity Concepts](foundational-cybersecurity-concepts/)
+- [Methodology](methodology/)

--- a/cybersecurity-domains/governance-risk-compliance/README.md
+++ b/cybersecurity-domains/governance-risk-compliance/README.md
@@ -1,0 +1,5 @@
+# Governance, Risk, and Compliance
+
+Resources in this domain:
+
+- [Regulations](regulations/)

--- a/cybersecurity-domains/hardware-embedded-security/README.md
+++ b/cybersecurity-domains/hardware-embedded-security/README.md
@@ -1,0 +1,8 @@
+# Hardware and Embedded Security
+
+Resources in this domain:
+
+- [IoT Hacking](iot-hacking/)
+- [Car Hacking](car-hacking/)
+- [Mobile Security](mobile-security/)
+- [Game Hacking](game-hacking/)

--- a/cybersecurity-domains/infrastructure-network-security/README.md
+++ b/cybersecurity-domains/infrastructure-network-security/README.md
@@ -1,0 +1,8 @@
+# Infrastructure and Network Security
+
+Resources in this domain:
+
+- [Networking](networking/)
+- [Wireless Resources](wireless-resources/)
+- [VIRL Topologies](virl-topologies/)
+- [Packet Captures](pcaps/)

--- a/cybersecurity-domains/labs-practice/README.md
+++ b/cybersecurity-domains/labs-practice/README.md
@@ -1,0 +1,8 @@
+# Labs and Practice
+
+Resources in this domain:
+
+- [Vulnerable Servers](vulnerable-servers/)
+- [Capture the Flag](capture-the-flag/)
+- [Penetration Testing Reports](pen-testing-reports/)
+- [Build Your Own Lab](../../build-your-own-lab/)

--- a/cybersecurity-domains/offensive-security/README.md
+++ b/cybersecurity-domains/offensive-security/README.md
@@ -1,0 +1,17 @@
+# Offensive Security
+
+Resources in this domain:
+
+- [Reconnaissance](recon/)
+- [OSINT](osint/)
+- [Exploit Development](exploit-development/)
+- [Buffer Overflow Examples](buffer-overflow-examples/)
+- [Post-Exploitation](post-exploitation/)
+- [Metasploit Resources](metasploit-resources/)
+- [Payloads](more-payloads/)
+- [Cracking Passwords](cracking-passwords/)
+- [Social Engineering](social-engineering/)
+- [Bug Bounties](bug-bounties/)
+- [Fuzzing Resources](fuzzing-resources/)
+- [Adversarial Emulation](adversarial-emulation/)
+- [Reverse Engineering](reverse-engineering/)

--- a/training-reference/README.md
+++ b/training-reference/README.md
@@ -1,0 +1,11 @@
+# Training Reference
+
+This section contains cross-domain reference material and curated indexes.
+
+- [Cheat Sheets](cheat-sheets/)
+- [O'Reilly Resources](oreilly-resources/)
+- [Who and What to Follow](who-and-what-to-follow/)
+- [Organized Tool Indexes](organized-tools/)
+- [Additional Tools](additional_tools.md)
+- [More Tools](more_tools.md)
+- [New Tools](new_tools.md)


### PR DESCRIPTION
## Summary
- Adds landing pages for the new cybersecurity domain taxonomy.
- Adds placeholder landing pages for AI tracks, certification families, and training reference.
- Establishes the section anchors needed by the follow-on reorganization PRs.

## Test plan
- Not run; documentation-only structure change.

Closes #482

Made with [Cursor](https://cursor.com)