### PR TITLE
Add Cisco AITECH course materials

### DIFF
--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-1-resources.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-1-resources.md
@@ -1,0 +1,115 @@
+# Lesson 1-1: Introduction to Generative AI Models
+
+> Student follow-along resources, key concepts, and references for this sublesson.
+
+## Overview
+
+Generative AI refers to a class of machine learning systems that create new, original content — text, images, audio, video, or code — by learning statistical patterns from very large training datasets. This sublesson sets the foundation for the rest of the course by contrasting generative AI with traditional (predictive) AI, introducing the two dominant model families you will work with (Large Language Models and diffusion models), and explaining why model choice drives what you can actually build.
+
+## Learning objectives
+
+By the end of this sublesson you should be able to:
+
+- Define generative AI and explain how it differs from traditional, predictive AI.
+- Identify the two dominant families of modern generative models (LLMs and diffusion models) and the kinds of outputs each is best suited for.
+- Recognize the names of current flagship models (e.g., GPT, Claude, Gemini, Llama, DeepSeek, Stable Diffusion, Midjourney, DALL·E, Sora).
+- Explain at a high level what "autoregressive" generation and "diffusion" generation mean.
+- Justify why model-family choice matters when designing an AI application.
+
+## Key concepts
+
+### 1. Traditional AI vs. generative AI
+
+Traditional AI is built primarily to **analyze, classify, or predict**. It detects fraud, ranks search results, recommends products, forecasts demand, or labels images. It works *with* existing content.
+
+Generative AI is built to **create new content** that did not exist before. It writes, summarizes, codes, designs, and produces images, audio, and video. It is generally trained on much larger and more diverse datasets and is built on deep neural networks (most often transformers or diffusion architectures).
+
+| Dimension | Traditional AI | Generative AI |
+| --- | --- | --- |
+| Primary goal | Classify, predict, optimize | Generate new content |
+| Typical output | A label, score, or decision | Text, image, audio, video, code |
+| Data needs | Often smaller, structured datasets | Massive, diverse datasets |
+| Interpretability | Generally easier to interpret | Often a "black box" |
+| Example use cases | Fraud detection, churn prediction, recommendation | Chat assistants, image generation, code generation, content drafting |
+
+In practice, modern systems often combine both: traditional models route, score, and filter; generative models produce the user-facing content.
+
+### 2. The two dominant families in 2025–2026
+
+```mermaid
+flowchart TD
+    GenAI["Generative AI Models"]
+    LLM["Large Language Models (LLMs)<br/>autoregressive, transformer-based"]
+    Diff["Diffusion Models<br/>iterative noise-to-signal"]
+    Multi["Multimodal Systems<br/>text + image + audio + video"]
+
+    GenAI --> LLM
+    GenAI --> Diff
+    LLM --> Multi
+    Diff --> Multi
+
+    LLM --> LLMex["Examples:<br/>GPT, Claude, Gemini,<br/>Llama, DeepSeek, Mistral"]
+    Diff --> Diffex["Examples:<br/>Stable Diffusion, DALL·E,<br/>Midjourney, Sora"]
+```
+
+#### Large Language Models (LLMs)
+
+- **Architecture:** Built on the **transformer** architecture, which uses self-attention to weigh relationships between tokens across long sequences.
+- **Generation style:** **Autoregressive** — the model predicts the next **token** (a word, sub-word, or character) given all previous tokens, then feeds that prediction back in to predict the next token, one step at a time.
+- **Inputs/outputs:** Originally text-in, text-out. Modern flagship LLMs are now **multimodal**: they can accept and/or produce images, audio, and video as well.
+- **Flagship families (early 2026):** OpenAI **GPT-5.x**, Anthropic **Claude 4.x**, Google **Gemini 3.x**, Meta **Llama 4**, **DeepSeek-V3.x**, xAI **Grok 4**, Mistral, Microsoft **Phi** (small language models).
+- **2026 trends to know:**
+  - **Inference-time reasoning** ("thinking" / chain-of-thought / "Deep Think") instead of relying purely on bigger training runs.
+  - **Mixture-of-Experts (MoE)** architectures for efficiency at very large scale.
+  - **Small Language Models (SLMs)** for on-device, private, low-latency use cases.
+
+#### Diffusion models
+
+- **Core idea:** Learn to *reverse* a gradual noising process. During training the model sees data progressively corrupted with Gaussian noise; at inference it starts from pure random noise and **iteratively denoises** it into a coherent image, video frame, or other signal.
+- **Architecture:** Typically a U-Net (or transformer-based "DiT") that predicts the noise at each step. **Latent diffusion** models (e.g., Stable Diffusion) run this process in a compressed latent space via a Variational Autoencoder (VAE) for big efficiency gains.
+- **Conditioning:** Text prompts steer generation through techniques like **classifier-free guidance**, usually with a text encoder (often a CLIP-style or transformer encoder) feeding the U-Net.
+- **Strengths:** State-of-the-art **image and video generation** quality; high controllability via prompts, image references, and adapters (LoRA, ControlNet, DreamBooth).
+- **Examples:** **Stable Diffusion** (open-source, runs locally), **DALL·E** (OpenAI, integrated in ChatGPT), **Midjourney** (proprietary, known for an artistic look), **Sora** (OpenAI, video).
+- **2025 research direction — diffusion language models:** A growing line of work explores using diffusion to generate **text in parallel** rather than one token at a time, with the goal of faster inference than autoregressive LLMs. This is still emerging but worth tracking.
+
+### 3. Why this matters for an AI practitioner
+
+The model family you pick determines what your application can actually do, how it will be priced, and what its failure modes look like:
+
+- Need text understanding, summarization, chat, code, function calling, or tool use? → **LLM**.
+- Need to produce images, illustrations, marketing assets, product mockups, or video? → **Diffusion model**.
+- Need both — e.g., an assistant that interprets a user request *and* generates an image? → **Hybrid system** where an LLM plans/parses and calls a diffusion model (or a unified multimodal model that can do both).
+
+The rest of Lesson 1 builds directly on this:
+
+- **Lesson 1-2:** Major generative AI model families in detail.
+- **Lesson 1-3:** Cloud vs. local hosting trade-offs.
+- **Lesson 1-4:** Context windows and token management.
+- **Lesson 1-5:** Choosing models from AI hubs.
+- **Lesson 1-6:** Retrieval-Augmented Generation (RAG), embeddings, and vector databases.
+
+## Glossary
+
+- **Generative AI** — ML systems that create new content (text, image, audio, video, code) from learned patterns.
+- **Token** — The atomic unit an LLM reads and produces. Roughly a word or sub-word.
+- **Autoregressive generation** — Producing output one token at a time, each conditioned on all previous tokens.
+- **Transformer** — The neural-network architecture, based on self-attention, that underlies modern LLMs and many diffusion text encoders.
+- **Diffusion model** — A generative model that turns random noise into a coherent output through an iterative denoising process.
+- **Latent diffusion** — Diffusion performed in a compressed latent space rather than raw pixels, for speed and efficiency.
+- **Multimodal model** — A model that can ingest and/or produce more than one modality (e.g., text + images + audio).
+- **Mixture-of-Experts (MoE)** — An architecture that activates only a subset of "expert" sub-networks per input, scaling capacity without proportional compute cost.
+- **Small Language Model (SLM)** — A compact LLM optimized for on-device or edge use.
+- **RAG (Retrieval-Augmented Generation)** — Grounding a generative model in retrieved, up-to-date documents to improve accuracy and reduce hallucinations. Covered in Lesson 1-6.
+
+## Quick self-check
+
+1. Give one example of a task best handled by traditional AI and one best handled by generative AI.
+2. In one sentence, what does it mean for an LLM to be "autoregressive"?
+3. What is the core mechanism by which a diffusion model produces an image from a text prompt?
+4. Name one current flagship LLM and one current diffusion-based image or video model.
+5. Why might a real product use both an LLM and a diffusion model together?
+
+## References and further reading
+
+- [Agentic AI for Cybersecurity: Building Autonomous Defenders and Adversaries](https://www.oreilly.com/library/view/agentic-ai-for/9780135589861/)
+- [Beyond the Algorithm: AI, Security, Privacy, and Ethics](https://learning.oreilly.com/library/view/beyond-the-algorithm/9780138268442)

--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/README.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/README.md
@@ -1,0 +1,3 @@
+# Lesson 1: Generative AI Models
+
+Resources and notes for Lesson 1 of the Cisco AI Technical Practitioner (AITECH) course.

--- a/certifications/cisco/AITECH/Lesson-2-Prompt-Engineering/README.md
+++ b/certifications/cisco/AITECH/Lesson-2-Prompt-Engineering/README.md
@@ -1,0 +1,3 @@
+# Lesson 2: Prompt Engineering
+
+Resources and notes for Lesson 2 of the Cisco AI Technical Practitioner (AITECH) course.

--- a/certifications/cisco/AITECH/Lesson-3-AI-Ethics-and-Security/README.md
+++ b/certifications/cisco/AITECH/Lesson-3-AI-Ethics-and-Security/README.md
@@ -1,0 +1,3 @@
+# Lesson 3: AI Ethics and Security
+
+Resources and notes for Lesson 3 of the Cisco AI Technical Practitioner (AITECH) course.

--- a/certifications/cisco/AITECH/Lesson-4-Data-Research-and-Analysis/README.md
+++ b/certifications/cisco/AITECH/Lesson-4-Data-Research-and-Analysis/README.md
@@ -1,0 +1,3 @@
+# Lesson 4: Data Research and Analysis
+
+Resources and notes for Lesson 4 of the Cisco AI Technical Practitioner (AITECH) course.

--- a/certifications/cisco/AITECH/Lesson-5-AI-for-Code-and-Workflow-Optimization/README.md
+++ b/certifications/cisco/AITECH/Lesson-5-AI-for-Code-and-Workflow-Optimization/README.md
@@ -1,0 +1,3 @@
+# Lesson 5: AI for Code and Workflow Optimization
+
+Resources and notes for Lesson 5 of the Cisco AI Technical Practitioner (AITECH) course.

--- a/certifications/cisco/AITECH/Lesson-6-Agentic-AI/README.md
+++ b/certifications/cisco/AITECH/Lesson-6-Agentic-AI/README.md
@@ -1,0 +1,3 @@
+# Lesson 6: Agentic AI
+
+Resources and notes for Lesson 6 of the Cisco AI Technical Practitioner (AITECH) course.

--- a/certifications/cisco/AITECH/README.md
+++ b/certifications/cisco/AITECH/README.md
@@ -1,0 +1,66 @@
+# Cisco AI Technical Practitioner (AITECH)
+
+This repository contains supplemental material for the **Cisco AI Technical Practitioner (AITECH)** course recorded by **Omar Santos**. The course is designed to help technical professionals build practical, job-ready AI skills and prepare for the Cisco AI Technical Practitioner certification exam.
+
+The AITECH certification validates the ability to apply AI in real technical workflows: using generative AI models, engineering effective prompts, analyzing and preparing data, improving code and automation workflows, understanding agentic AI systems, and applying AI ethics, privacy, security, and governance practices. Cisco positions the certification for IT and network engineers, data analysts, AIOps specialists, solutions architects, technical leads, managers, and business process analysts who want to move from AI awareness to hands-on implementation.
+
+To earn the certification, candidates must pass the **Cisco AI Technical Practitioner (810-110 AITECH) v1.0** exam. Cisco lists the exam duration as **60 minutes** and describes the exam as covering generative AI models, prompt engineering, AI ethics and security, agentic AI, and other practical AI implementation topics.
+
+## About This Course
+
+This course follows the practitioner mindset of the certification: focus on how AI can be used responsibly and effectively in real technical work. The lessons introduce core generative AI concepts, prompt engineering patterns, responsible AI and security concerns, AI-assisted data analysis, coding and workflow optimization, and agentic AI design.
+
+Use these materials as a companion to the recorded course. Each lesson is organized to support review, hands-on practice, and exam preparation.
+
+## Video Course Outline
+
+### Lesson 1: Generative AI Models
+- Lesson 1-1: Introduction to Generative AI Models
+- Lesson 1-2: Major Generative AI Model Families
+- Lesson 1-3: Model Hosting Options
+- Lesson 1-4: Context Windows and Token Management
+- Lesson 1-5: Model Selection in AI Hubs
+- Lesson 1-6: Retrieval Augmented Generation (RAG), Embeddings, and Vector Databases
+
+### Lesson 2: Prompt Engineering
+- Lesson 2-1: Introduction to Prompt Engineering
+- Lesson 2-2: Prompt Engineering Principles and Patterns
+- Lesson 2-3: Prompting Techniques
+- Lesson 2-4: Prompt Injection Attack Types
+- Lesson 2-5: Defensive Prompting and Error Mitigation
+
+### Lesson 3: AI Ethics and Security
+- Lesson 3-1: Introduction to AI Ethics and Security
+- Lesson 3-2: Responsible AI Principles
+- Lesson 3-3: Corporate Data Privacy and Security Approaches
+- Lesson 3-4: AI Security Threats and Risks
+- Lesson 3-5: AI Governance Considerations
+
+### Lesson 4: Data Research and Analysis
+- Lesson 4-1: Introduction to Data Research and Analysis
+- Lesson 4-2: AI's Role in Exploratory Data Analysis (EDA)
+- Lesson 4-3: Automated Data Preparation
+- Lesson 4-4: Ethical and Privacy Considerations
+- Lesson 4-5: AI-Assisted Research, Ideation, and Content Drafting
+
+### Lesson 5: AI for Code and Workflow Optimization
+- Lesson 5-1: Introduction to AI for Code and Workflow Optimization
+- Lesson 5-2: AI's Role Across the Software Development Lifecycle
+- Lesson 5-3: Code Generation and Rapid Prototyping
+- Lesson 5-4: AI Workflow Design and Monitoring
+- Lesson 5-5: Token Usage and Context Window Management
+- Lesson 5-6: Code Quality Improvement with AI
+
+### Lesson 6: Agentic AI
+- Lesson 6-1: Introduction to Agentic AI
+- Lesson 6-2: Agentic AI vs. Generative AI
+- Lesson 6-3: Agentic AI Design Principles
+- Lesson 6-4: Model Context Protocol (MCP)
+- Lesson 6-5: Human-in-the-Loop (HITL) Strategies
+- Lesson 6-6: Data Transformation in AI Agents
+
+## References
+
+- [Cisco AI Technical Practitioner certification overview](https://www.cisco.com/site/us/en/learn/training-certifications/certifications/ai/technical-practitioner/index.html)
+- [Cisco AITECH exam and training](https://www.cisco.com/site/us/en/learn/training-certifications/certifications/ai/technical-practitioner/exam.html)
+- [Cisco AI Technical Practitioner training course](https://www.cisco.com/site/us/en/learn/training-certifications/training/courses/aitech.html)


### PR DESCRIPTION
## Summary
- Add the Cisco AI Technical Practitioner (AITECH) course landing page with certification context and references.
- Add lesson folders for the six course sections with starter README files.
- Include the Lesson 1-1 generative AI resources under the Lesson 1 course folder.

## Test plan
- Checked markdown diagnostics for the edited AITECH README.

Closes #496

Made with [Cursor](https://cursor.com)