### PR TITLE
Add AITECH Lesson 1-5 through 1-8 resources

### DIFF
--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-5-resources.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-5-resources.md
@@ -1,0 +1,90 @@
+# Lesson 1-5: Using Open Weight Models and Introducing Hugging Face
+
+> Student follow-along resources, key concepts, and references for this sublesson.
+
+## Overview
+
+Open-weight models give you direct access to model parameters, so you can run, fine-tune, and deploy AI systems with much more control than API-only proprietary models. In practice, most teams discover and evaluate these models through Hugging Face, which has become the central ecosystem for model repositories, model cards, dataset artifacts, leaderboards, and deployment pathways. This sublesson explains what "open weight" really means, how to work safely with licenses, and how to use Hugging Face Hub as a practical workflow from discovery to deployment.
+
+## Learning objectives
+
+By the end of this sublesson you should be able to:
+
+- Explain the difference between open source AI, open weight models, and closed APIs.
+- Find models on Hugging Face using filters for task, license, framework, and hardware fit.
+- Read model cards to assess suitability, risks, and deployment constraints.
+- Identify common open-weight deployment paths (local, cloud endpoint, self-hosted inference).
+- Avoid common legal and operational mistakes when choosing open-weight models.
+
+## Key concepts
+
+### 1. Open weight does not always mean fully open source
+
+- **Open weight** means model parameters are available for download and local use.
+- **Fully open source AI** is stricter: weights, code, and (ideally) training data/procedure transparency.
+- Some "open" models still include restricted licenses (for example, non-commercial clauses or usage limitations).
+- Treat licensing as a production requirement, not an afterthought.
+
+### 2. Hugging Face as the model operating system
+
+```mermaid
+flowchart LR
+    Need["Use case + constraints"] --> Discover["Discover models on Hub"]
+    Discover --> Filter["Filter by task/license/size"]
+    Filter --> Cards["Review model cards"]
+    Cards --> Test["Run eval on your data"]
+    Test --> Deploy["Deploy: local, endpoint, or cloud"]
+```
+
+Hugging Face Hub is where many teams do all of the following:
+
+- Discover checkpoints and model families.
+- Review model cards and usage snippets.
+- Compare leaderboard signals.
+- Host internal derivatives and fine-tuned adapters.
+- Deploy via Inference Endpoints or provider integrations.
+
+### 3. A practical selection checklist
+
+When evaluating an open-weight model, check:
+
+1. **License fit** for commercial usage and redistribution.
+2. **Hardware fit** (VRAM, precision, quantized variants).
+3. **Task fit** (reasoning, coding, multilingual, multimodal).
+4. **Operational fit** (latency, throughput, observability, guardrails).
+5. **Safety and known limits** documented in the model card.
+
+### 4. Common mistakes to avoid
+
+- Choosing by hype or benchmark headlines only.
+- Ignoring tokenizer/context differences across model families.
+- Skipping evaluation on your own prompts and datasets.
+- Assuming larger parameter count always means better outcomes.
+
+## Why it matters / What's next
+
+Open-weight literacy gives you leverage: better portability, lower lock-in, and more deployment flexibility. Once you can reliably choose and run open models, the next step is improving knowledge freshness and factual grounding. That is the focus of **Lesson 1-6: Retrieval Augmented Generation (RAG), Embeddings, and Vector Databases**.
+
+## Glossary
+
+- **Open weight model** — A model with downloadable parameters (weights), usually runnable outside a vendor API.
+- **Model card** — Structured documentation describing intended use, limitations, evaluation, and licensing.
+- **Inference endpoint** — Hosted API serving a chosen model.
+- **Quantization** — Lower-precision representation (for example INT8/INT4) used to reduce memory and cost.
+- **Checkpoint** — Saved model state that can be loaded for inference or further fine-tuning.
+
+## Quick self-check
+
+1. Why is "open weight" not always equal to "fully open source AI"?
+2. Which three fields in a model card should you read before downloading a model?
+3. What are two deployment options for a Hugging Face model besides running it on your laptop?
+4. Why can a smaller quantized model be better than a larger model for some workloads?
+
+## References and further reading
+
+- [Hugging Face Hub Documentation](https://huggingface.co/docs/hub/index)
+- [Hugging Face Model Hub](https://huggingface.co/docs/hub/models-the-hub)
+- [Hugging Face Model Cards](https://huggingface.co/docs/hub/model-cards)
+- [Hugging Face Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index)
+- [State of Open Source on Hugging Face (Spring 2026)](https://huggingface.co/blog/huggingface/state-of-os-hf-spring-2026)
+- [Open Source AI Collection (Hugging Face)](https://huggingface.co/collections/mindchain/open-source-ai-fully-open-weights-and-training-data)

--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-6-resources.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-6-resources.md
@@ -1,0 +1,95 @@
+# Lesson 1-6: Retrieval Augmented Generation (RAG), Embeddings, and Vector Databases
+
+> Student follow-along resources, key concepts, and references for this sublesson.
+
+## Overview
+
+Retrieval Augmented Generation (RAG) is the most common way to make LLM applications grounded in your own current knowledge. Instead of relying only on model pretraining, RAG retrieves relevant chunks from your documents at query time and injects them into the prompt. This sublesson covers the three core building blocks: embeddings, vector search, and generation with cited context.
+
+## Learning objectives
+
+By the end of this sublesson you should be able to:
+
+- Explain the end-to-end RAG workflow from ingestion to answer generation.
+- Describe how embeddings convert text into vectors for semantic retrieval.
+- Compare vector database choices and why approximate nearest-neighbor indexing matters.
+- Identify where hallucinations and retrieval misses happen in RAG systems.
+- Design a basic RAG pipeline with chunking, top-k retrieval, and answer synthesis.
+
+## Key concepts
+
+### 1. The RAG pipeline at a glance
+
+```mermaid
+flowchart TD
+    Docs["Source documents"] --> Chunk["Chunk + clean text"]
+    Chunk --> Embed["Generate embeddings"]
+    Embed --> Store["Store vectors + metadata"]
+    UserQ["User query"] --> QEmbed["Embed query"]
+    QEmbed --> Retrieve["Vector search top-k"]
+    Store --> Retrieve
+    Retrieve --> Prompt["Assemble grounded prompt"]
+    Prompt --> LLM["LLM generates response"]
+    LLM --> Answer["Answer with citations"]
+```
+
+### 2. Embeddings are the retrieval interface
+
+- Embeddings map text to dense numeric vectors so semantically similar content is nearby in vector space.
+- You must use the same embedding model family for indexing and querying.
+- Embedding quality drives retrieval quality more than prompt wording does in many RAG systems.
+- Dimension size, language coverage, and domain fit directly impact accuracy and cost.
+
+### 3. Vector databases: speed and recall trade-offs
+
+Vector databases optimize nearest-neighbor search over high-dimensional vectors using ANN indexes such as HNSW or IVF variants.
+
+Key capabilities to evaluate:
+
+- Metadata filtering (tenant, product, date, ACL).
+- Hybrid retrieval (keyword + vector) for better precision.
+- Update behavior and reindex cost.
+- Recall/latency behavior at your expected scale.
+
+### 4. Failure modes and mitigations
+
+- **Bad chunking** -> retrieved context is incomplete or fragmented.
+- **Embedding mismatch** -> semantically relevant chunks are not surfaced.
+- **Over-retrieval** -> noisy context lowers answer quality.
+- **No grounding policy** -> model invents unsupported claims.
+
+Common mitigations:
+
+- Chunk by semantic boundaries with overlap.
+- Use top-k + reranking.
+- Force citation-required output format.
+- Evaluate retrieval and generation separately.
+
+## Why it matters / What's next
+
+RAG is the bridge between static model knowledge and dynamic business knowledge. If your use case depends on internal docs, changing policies, product catalogs, or incident history, RAG is often mandatory. In the next sublesson, **Lesson 1-7: Understanding Agentic RAG**, you will extend this pattern with planning and tool-using retrieval agents.
+
+## Glossary
+
+- **RAG** — Retrieval Augmented Generation; retrieve relevant context first, then generate.
+- **Embedding** — Dense vector representation of text semantics.
+- **Vector database** — System optimized for storing and searching embeddings.
+- **ANN search** — Approximate nearest-neighbor methods for fast semantic retrieval.
+- **Top-k retrieval** — Returning the k most similar chunks for a query.
+- **Reranker** — A second-stage model that reorders retrieved results for relevance.
+
+## Quick self-check
+
+1. Why should indexing and query embeddings usually come from the same model family?
+2. What is the difference between vector retrieval and reranking?
+3. Give two reasons a RAG system can hallucinate even when using retrieval.
+4. When would hybrid search (keyword + vector) outperform vector-only search?
+
+## References and further reading
+
+- [OpenAI Embeddings Guide](https://developers.openai.com/api/docs/guides/embeddings)
+- [OpenAI Retrieval Guide](https://developers.openai.com/api/docs/guides/retrieval)
+- [Microsoft Learn: Generate Embeddings for RAG](https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/rag/rag-generate-embeddings)
+- [Pinecone: What is Retrieval Augmented Generation?](https://www.pinecone.io/learn/retrieval-augmented-generation/)
+- [NVIDIA: What is a Vector Database?](https://www.nvidia.com/en-us/glossary/vector-database/)
+- [MTEB Benchmark (GitHub)](https://github.com/embeddings-benchmark/mteb)

--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-7-resources.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-7-resources.md
@@ -1,0 +1,97 @@
+# Lesson 1-7: Understanding Agentic RAG
+
+> Student follow-along resources, key concepts, and references for this sublesson.
+
+## Overview
+
+Agentic RAG extends classic retrieval pipelines by adding an agent loop that can plan, decide which tools to call, iterate retrieval, critique intermediate outputs, and stop when confidence is sufficient. Instead of a single "retrieve then generate" pass, agentic systems can decompose complex questions, gather evidence from multiple sources, and verify their answers before returning results.
+
+## Learning objectives
+
+By the end of this sublesson you should be able to:
+
+- Explain how agentic RAG differs from standard one-pass RAG.
+- Describe planner, retriever, tool-caller, and verifier roles in an agentic workflow.
+- Identify cases where multi-step retrieval materially improves answer quality.
+- Recognize risks such as runaway loops, tool misuse, and prompt-injection propagation.
+- Define guardrails for reliable and auditable agentic retrieval.
+
+## Key concepts
+
+### 1. Standard RAG vs agentic RAG
+
+```mermaid
+flowchart LR
+    Q["User question"] --> Plan["Plan next step"]
+    Plan --> Decide{"Need more evidence?"}
+    Decide -->|Yes| Retrieve["Retrieve / call tool"]
+    Retrieve --> Reflect["Reflect + critique"]
+    Reflect --> Decide
+    Decide -->|No| Synthesize["Synthesize grounded answer"]
+    Synthesize --> Output["Final response + citations"]
+```
+
+In standard RAG, retrieval usually happens once. In agentic RAG, retrieval can be iterative and conditional.
+
+### 2. Core components in an agentic loop
+
+- **Planner** — breaks the task into sub-questions.
+- **Retriever/tool router** — decides which index, source, or API to query.
+- **Reasoner** — integrates evidence and tracks what is still unknown.
+- **Verifier/reflection step** — checks evidence quality and consistency before final output.
+
+### 3. When agentic RAG is worth the complexity
+
+Good use cases:
+
+- Multi-hop questions spanning many documents.
+- Incident response and operations triage with evolving evidence.
+- Enterprise assistants that must combine policies, tickets, and live system signals.
+
+Less suitable:
+
+- Simple FAQ retrieval where one-shot RAG is already accurate.
+- Strict low-latency workloads where iterative loops are too expensive.
+
+### 4. Risks and controls
+
+Main risks:
+
+- Infinite or long loops with little quality gain.
+- Prompt injection from retrieved content.
+- Tool overreach (querying systems beyond intended scope).
+- Unverifiable final answers.
+
+Baseline controls:
+
+- Max iterations / timeout budgets.
+- Tool allow-lists and schema-validated function calls.
+- Retrieval sanitization and content trust labels.
+- Mandatory citations plus confidence/uncertainty signaling.
+
+## Why it matters / What's next
+
+Agentic RAG is how teams handle harder questions that require planning, not just lookup. It can dramatically improve coverage on complex tasks, but only when paired with strict controls and evaluation. Next, **Lesson 1-8: Vector Databases and Embedding Models** dives deeper into the retrieval substrate that both standard and agentic RAG depend on.
+
+## Glossary
+
+- **Agentic RAG** — RAG with an autonomous planning-and-tool-use loop.
+- **Multi-hop retrieval** — Retrieving and connecting evidence across multiple steps or sources.
+- **Tool calling** — Structured invocation of external tools/APIs by an LLM.
+- **Reflection** — Self-critique or verification pass before final answer.
+- **Guardrail** — Runtime constraint that limits unsafe or unreliable model behavior.
+
+## Quick self-check
+
+1. What is one concrete benefit of agentic RAG over one-pass RAG?
+2. Which guardrails prevent agent loops from becoming expensive or unsafe?
+3. Why can prompt injection be more dangerous in agentic pipelines?
+4. When should you deliberately choose non-agentic RAG instead?
+
+## References and further reading
+
+- [LlamaIndex: Agentic RAG With LlamaIndex](https://www.llamaindex.ai/blog/agentic-rag-with-llamaindex-2721b8a49ff6)
+- [LlamaIndex: Agentic Retrieval Guide](https://www.llamaindex.ai/blog/rag-is-dead-long-live-agentic-retrieval)
+- [Agentic Retrieval-Augmented Generation: Survey (arXiv)](https://arxiv.org/abs/2501.09136)
+- [Google Cloud: Design Patterns for Agentic AI Systems](https://cloud.google.com/architecture/choose-design-pattern-agentic-ai-system)
+- [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)

--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-8-resources.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-8-resources.md
@@ -1,0 +1,94 @@
+# Lesson 1-8: Vector Databases and Embedding Models
+
+> Student follow-along resources, key concepts, and references for this sublesson.
+
+## Overview
+
+Embedding models and vector databases form the retrieval backbone of modern AI applications. Embeddings convert unstructured content into vectors; vector databases index those vectors for fast semantic search. This sublesson focuses on how to choose embedding models, how vector index design affects quality and latency, and what to measure when operating retrieval in production.
+
+## Learning objectives
+
+By the end of this sublesson you should be able to:
+
+- Explain how embedding model quality influences downstream retrieval accuracy.
+- Compare cosine similarity, dot product, and Euclidean distance in practical retrieval.
+- Describe common vector indexing approaches (for example HNSW) and their trade-offs.
+- Choose an embedding/vector stack based on data scale, latency, and filtering needs.
+- Define an evaluation workflow for retrieval quality and system performance.
+
+## Key concepts
+
+### 1. Embedding model selection
+
+Selection criteria should include:
+
+- **Task fit** (semantic search, clustering, reranking pipeline compatibility).
+- **Domain/language fit** (general text vs legal, medical, code, multilingual corpora).
+- **Dimension and storage footprint** (higher dimensions can improve signal but raise cost).
+- **Serving constraints** (throughput, batching, latency, and provider lock-in concerns).
+
+Use public benchmarks as a starting point, then validate on your own dataset.
+
+### 2. Vector database internals that matter in practice
+
+```mermaid
+flowchart TD
+    Vectors["Embeddings"] --> Index["ANN index (e.g., HNSW/IVF)"]
+    Query["Query embedding"] --> Search["Similarity search"]
+    Index --> Search
+    Search --> Filter["Metadata/ACL filters"]
+    Filter --> Rerank["Optional reranker"]
+    Rerank --> Results["Top results to LLM"]
+```
+
+Practical concerns:
+
+- ANN parameters tune recall vs latency.
+- Metadata filters are critical for multi-tenant and policy-safe retrieval.
+- Reindex strategies affect freshness and ingestion cost.
+
+### 3. Similarity metrics and consistency
+
+- **Cosine similarity** is common for normalized semantic vectors.
+- **Dot product** is often used with provider defaults and large-scale ANN engines.
+- **L2/Euclidean** can work well depending on model training objective.
+
+Whichever metric you choose, maintain consistency across indexing, querying, and benchmarking.
+
+### 4. Evaluation and observability
+
+Evaluate two layers separately:
+
+1. **Retrieval quality** (recall@k, precision@k, nDCG, hit rate on gold passages).
+2. **System performance** (p95 latency, QPS throughput, index memory, ingestion lag).
+
+In production, monitor retrieval drift when documents, user behavior, or embedding models change.
+
+## Why it matters / What's next
+
+Even the best LLM cannot answer correctly if retrieval surfaces weak context. Choosing the right embedding model and vector database is therefore a first-order product decision, not just infrastructure plumbing. This closes Lesson 1's foundational path from model basics to practical AI system design.
+
+## Glossary
+
+- **Embedding model** — Model that maps text (or other modalities) into dense vectors.
+- **Vector index** — Data structure optimized for nearest-neighbor lookup.
+- **HNSW** — Graph-based ANN indexing method widely used for fast high-recall search.
+- **Recall@k** — Fraction of relevant items found in top-k retrieved results.
+- **nDCG** — Ranking quality metric that rewards relevant items appearing higher in results.
+- **Retrieval drift** — Gradual retrieval quality degradation as data/distribution changes.
+
+## Quick self-check
+
+1. Why can a strong embedding model still perform poorly with the wrong index settings?
+2. What is the practical difference between recall@k and latency metrics?
+3. When would metadata filtering be mandatory, not optional?
+4. Why should benchmark winners still be tested on your own corpus before adoption?
+
+## References and further reading
+
+- [MTEB Benchmark Repository](https://github.com/embeddings-benchmark/mteb)
+- [MTEB Leaderboard (Hugging Face)](https://huggingface.co/spaces/mteb/leaderboard)
+- [OpenAI Embeddings Guide](https://developers.openai.com/api/docs/guides/embeddings)
+- [NVIDIA: What is a Vector Database?](https://www.nvidia.com/en-us/glossary/vector-database/)
+- [Milvus: What Is a Vector Database?](https://milvus.io/blog/what-is-a-vector-database.md)
+- [Qdrant Documentation](https://qdrant.tech/documentation/)


### PR DESCRIPTION
## Summary
- Add AITECH Lesson 1-5 resources for open-weight models and Hugging Face.
- Add Lesson 1-6 and 1-7 resources covering RAG and agentic RAG workflows.
- Add Lesson 1-8 resources for vector databases and embedding model selection.

## Test plan
- Checked markdown diagnostics for the new resource files.

Closes #504

Made with [Cursor](https://cursor.com)