### PR TITLE
Add AITECH hackertraining references

### DIFF
--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-5-resources.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-5-resources.md
@@ -81,7 +81,7 @@ Open-weight literacy gives you leverage: better portability, lower lock-in, and 
 4. Why can a smaller quantized model be better than a larger model for some workloads?
 
 ## References and further reading
-
+- [Amazing resources related to AI and Cybersecurity](https://hackertraining.org/)
 - [Hugging Face Hub Documentation](https://huggingface.co/docs/hub/index)
 - [Hugging Face Model Hub](https://huggingface.co/docs/hub/models-the-hub)
 - [Hugging Face Model Cards](https://huggingface.co/docs/hub/model-cards)

--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-6-resources.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-6-resources.md
@@ -86,7 +86,7 @@ RAG is the bridge between static model knowledge and dynamic business knowledge.
 4. When would hybrid search (keyword + vector) outperform vector-only search?
 
 ## References and further reading
-
+- [Amazing resources related to AI and Cybersecurity](https://hackertraining.org/)
 - [OpenAI Embeddings Guide](https://developers.openai.com/api/docs/guides/embeddings)
 - [OpenAI Retrieval Guide](https://developers.openai.com/api/docs/guides/retrieval)
 - [Microsoft Learn: Generate Embeddings for RAG](https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/rag/rag-generate-embeddings)

--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-7-resources.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-7-resources.md
@@ -89,7 +89,7 @@ Agentic RAG is how teams handle harder questions that require planning, not just
 4. When should you deliberately choose non-agentic RAG instead?
 
 ## References and further reading
-
+- [Amazing resources related to AI and Cybersecurity](https://hackertraining.org/)
 - [LlamaIndex: Agentic RAG With LlamaIndex](https://www.llamaindex.ai/blog/agentic-rag-with-llamaindex-2721b8a49ff6)
 - [LlamaIndex: Agentic Retrieval Guide](https://www.llamaindex.ai/blog/rag-is-dead-long-live-agentic-retrieval)
 - [Agentic Retrieval-Augmented Generation: Survey (arXiv)](https://arxiv.org/abs/2501.09136)

--- a/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-8-resources.md
+++ b/certifications/cisco/AITECH/Lesson-1-Generative-AI-Models/Lesson-1-8-resources.md
@@ -85,7 +85,7 @@ Even the best LLM cannot answer correctly if retrieval surfaces weak context. Ch
 4. Why should benchmark winners still be tested on your own corpus before adoption?
 
 ## References and further reading
-
+- [Amazing resources related to AI and Cybersecurity](https://hackertraining.org/)
 - [MTEB Benchmark Repository](https://github.com/embeddings-benchmark/mteb)
 - [MTEB Leaderboard (Hugging Face)](https://huggingface.co/spaces/mteb/leaderboard)
 - [OpenAI Embeddings Guide](https://developers.openai.com/api/docs/guides/embeddings)


### PR DESCRIPTION
## Summary
- Add the hackertraining.org AI and cybersecurity resource link to AITECH Lesson 1-5 through Lesson 1-8 references.
- Keep the update scoped to the existing reference sections for these lesson resource pages.

## Test plan
- Checked markdown diagnostics for the updated resource files.

Closes #506

Made with [Cursor](https://cursor.com)