### PR TITLE
Update cloud-based cyber ranges in README

### DIFF
--- a/build-your-own-lab/README.md
+++ b/build-your-own-lab/README.md
@@ -53,7 +53,7 @@ Ludus is implemented as a server that runs Packer and Ansible to create template
 ## Cloud-Based Cyber Ranges
 - [Awesome Cloud Labs](https://github.com/iknowjason/Awesome-CloudSec-Labs): A list of free cloud native security learning labs. Includes CTF, self-hosted workshops, guided vulnerability labs, and research labs.
 - [PurpleCloud](https://github.com/iknowjason/PurpleCloud):  Cyber Range environment created by [Jason Ostrom](https://twitter.com/securitypuck) using Active Directory and automated templates for building your own Pentest/Red Team/Cyber Range in the Azure cloud!
-- [CyberRange by SECDEVOPS@CUSE](https://github.com/secdevops-cuse/CyberRange): AWS-based Cyber Range.
+- [OpenClaw 🦞 and DefenseClaw lab](https://developer.cisco.com/learning/labs/OpenClawSecurity/why-openclaw-%f0%9f%a6%9e-needs-defenseclaw/): OpenClaw is designed to run tools, touch files, and connect extra capabilities through skills, plugins, and MCP servers. In this lab you will use it the way a normal team would: install it, point it at the lab-provided model endpoint, and prove the agent is alive. Then you will watch how quickly the trust boundary changes when a believable helper turns malicious.
 - [Create A VPS On Google Cloud Platform Or Digital Ocean Easily With The Docker For Pentest](https://github.com/aaaguirrep/offensive-docker-vps)
 - [How to Build a Cloud Hacking Lab](https://www.youtube.com/watch?v=4s_3oNwqImo)
 - [Splunk Attack Range](https://github.com/splunk/attack_range)


### PR DESCRIPTION
Replaced a link to 'CyberRange by SECDEVOPS@CUSE' with a link to 'OpenClaw and DefenseClaw lab' in the README.

- Fixes #512 

This pull request updates the cloud-based cyber ranges section in the `build-your-own-lab/README.md` file by replacing an existing AWS-based cyber range resource with a new lab focused on OpenClaw and DefenseClaw. The new entry provides a more detailed description of the lab's purpose and activities.

Resource updates:

* Replaced the "CyberRange by SECDEVOPS@CUSE" AWS-based cyber range entry with a new listing for "OpenClaw 🦞 and DefenseClaw lab," including a description of its features and objectives.