### PR TITLE
Add Pentest Mindmap — interactive 11,600+ pentesting commands reference

### DIFF
--- a/training-reference/more_tools.md
+++ b/training-reference/more_tools.md
@@ -882,3 +882,5 @@ The following are a collection of recently-released pen test tools. I update thi
 - [Recaf - A Modern Java Bytecode Editor](http://feedproxy.google.com/~r/PentestTools/~3/mAzq3GzpHIg/recaf-modern-java-bytecode-editor.html)
 - [dnSpy - .NET Debugger And Assembly Editor](http://feedproxy.google.com/~r/PentestTools/~3/JZaPW594CQE/dnspy-net-debugger-and-assembly-editor.html)
 - [DotDotPwn - The Directory Traversal Fuzzer](https://github.com/wireghoul/dotdotpwn)
+
+- [Pentest Mindmap](https://pentestmindmap.com) - Interactive mindmap with 11,600+ pentesting commands organized by category (web, AD, privesc, network, OSCP, forensics and more)


### PR DESCRIPTION
## What is this?

[Pentest Mindmap](https://pentestmindmap.com) is a free interactive mindmap with 11,600+ pentesting commands organized by category.

**Why it belongs here:**
- Covers offensive security topics: web, AD, privesc, network, OSCP, forensics
- Interactive D3.js mindmap — 32 attack categories
- Complements the existing tools and references in this repo
- Free to explore