### PR TITLE
Update README.md

### DIFF
--- a/cybersecurity-domains/offensive-security/post-exploitation/README.md
+++ b/cybersecurity-domains/offensive-security/post-exploitation/README.md
@@ -51,6 +51,7 @@
 * [GTFO Bins](https://gtfobins.github.io/)
 * [LOLBAS](https://github.com/LOLBAS-Project/LOLBAS)
 * [NSA/CISA Guidance to Mitigate Living Off The Land Attacks](https://media.defense.gov/2024/Feb/07/2003389936/-1/-1/0/JOINT-GUIDANCE-IDENTIFYING-AND-MITIGATING-LOTL.PDF)
+* [LOOBins for macOS](https://github.com/infosecB/LOOBins)
 
 ## Command and Control
 * [C2 Matrix](https://www.thec2matrix.com/)


### PR DESCRIPTION
This pull request adds a new resource link to the post-exploitation section in the offensive security documentation. The addition provides users with an extra reference for macOS-specific Living Off the Orchard Binaries (LOOBins).

Resource additions:

* Added a link to the `LOOBins for macOS` project in the `cybersecurity-domains/offensive-security/post-exploitation/README.md` file to expand resources for macOS post-exploitation techniques.