### PR TITLE
docs: fix malformed URL scheme in docker resources

### DIFF
--- a/build-your-own-lab/docker_resources.md
+++ b/build-your-own-lab/docker_resources.md
@@ -27,7 +27,7 @@
 - [bocker](https://github.com/icy/bocker) (2) - Write Dockerfile completely in Bash. Extensible and simple. --> Reusable by [@icy](https://github.com/icy)
 - [box](https://github.com/box-builder/box) - Build Dockerfile images with a mruby DSL, includes flattening and layer manipulation
 - [Capitan](https://github.com/byrnedo/capitan) - Composable docker orchestration with added scripting support by [@byrnedo](https://github.com/byrnedo).
-- [compose_plantuml](hhttps://github.com/funkwerk/compose_plantuml) -  Generate Plantuml graphs from docker-compose files by [@funkwerk](https://github.com/funkwerk)
+- [compose_plantuml](https://github.com/funkwerk/compose_plantuml) -  Generate Plantuml graphs from docker-compose files by [@funkwerk](https://github.com/funkwerk)
 - [Composerize](https://github.com/magicmark/composerize) - Convert docker run commands into docker-compose files
 - [crowdr](https://github.com/polonskiy/crowdr) - Tool for managing multiple Docker containers (`docker-compose` alternative) by [@polonskiy](https://github.com/polonskiy/)
 - [docker-compose-graphviz](https://github.com/abesto/docker-compose-graphviz) - Turn a docker-compose.yml files into Graphviz .dot files by [@abesto](https://github.com/abesto)


### PR DESCRIPTION
In `build-your-own-lab/docker_resources.md`, the compose_plantuml link uses a malformed URL scheme:

> `[compose_plantuml](hhttps://github.com/funkwerk/compose_plantuml)`

`hhttps://` (a doubled `h`) is not a valid scheme, so the link does not resolve. The `@funkwerk` link on the same line already uses `https://`. This fixes the scheme.
