### PR TITLE
Add ScanMalware to OSINT Source Highlights

### DIFF
--- a/cybersecurity-domains/offensive-security/osint/README.md
+++ b/cybersecurity-domains/offensive-security/osint/README.md
@@ -73,6 +73,7 @@ Ethical hackers document their findings and provide insights to organizations on
 | crt.sh              | Certificate Search|
 | vulners.com         | Vulnerabilities    |
 | pulsedive.com       | Threat Intelligence|
+| scanmalware.com     | Threat Intelligence|
 
 ### Website Exploration and "Google Hacking"
 - censys : https://censys.io


### PR DESCRIPTION
I work on this one — ScanMalware is run by Triop AB in Sweden, so flagging that up front.

It's a free URL scanner: submit any URL and it renders the page in a sandboxed browser, then reports phishing and malware verdicts, network requests, form analysis, TLS/JARM fingerprints and screenshots. Scanning and the public scan feed need no account, and the REST API allows 600 requests/minute anonymously.

The part that fits this table specifically is the pivot: every scan is indexed, so from one phishing page you can find related infrastructure by favicon hash, JARM, ASN, screenshot hash or fuzzy hash, then follow it through Certificate Transparency and RDAP.

Added at the end of the table, matching the existing column widths. Categorised as Threat Intelligence, same as urlscan.io and pulsedive.com.

Also listed in [mesquidar/ForensicsTools](https://github.com/mesquidar/ForensicsTools) if that's useful context.