### PR TITLE
Add SearchWebCode to the OSINT source-code search tools

### DIFF
--- a/cybersecurity-domains/offensive-security/osint/README.md
+++ b/cybersecurity-domains/offensive-security/osint/README.md
@@ -66,6 +66,7 @@ Ethical hackers document their findings and provide insights to organizations on
 | searchcode.com      | Codes Search       |
 | urlscan.io          | Threat Intelligence|
 | publicwww.com       | Codes Search       |
+| searchwebcode.com   | Source Code Search |
 | fullhunt.io         | Attack Surface     |
 | socradar.io         | Threat Intelligence|
 | binaryedge.io       | Attack Surface     |


### PR DESCRIPTION
[SearchWebCode](https://www.searchwebcode.com) is an exact-string and regex search engine over the HTML, JS and CSS source of ~129M website homepages — a source-code search engine in the same category as PublicWWW, which this OSINT list already includes. Every result opens the full matched page source and the domain list is exportable as CSV. Added it right below the PublicWWW entry.

Disclosure: I'm affiliated with the project.