### PR TITLE
Add PRISM to the OSINT passive recon tools

### DIFF
--- a/cybersecurity-domains/offensive-security/osint/README.md
+++ b/cybersecurity-domains/offensive-security/osint/README.md
@@ -29,6 +29,7 @@ Ethical hackers document their findings and provide insights to organizations on
 - [FOCA](https://elevenpaths.com)
 - [IntelTechniques](https://inteltechniques.com)
 - [Maltego](https://www.paterva.com/web7/)
+- [PRISM](https://github.com/NovaCode37/Prism-platform) - Self-hosted OSINT platform with a web dashboard: domains, IPs, emails, phone numbers and usernames across 22+ modules, with an exposure score, entity graph and HTML/PDF reports.
 - [Recon-NG](https://github.com/lanmaster53/recon-ng)
 - [Scrapy](https://scrapy.org)
 - [Screaming Frog](https://www.screamingfrog.co.uk)


### PR DESCRIPTION
Adds PRISM to the passive recon tools list, in alphabetical position.

PRISM is a self-hosted OSINT platform: you run it yourself and scan domains, IPs, emails, phone numbers or usernames from a web dashboard. It covers WHOIS, DNS, certificate transparency, breach lookups and username search across 50+ platforms, produces an exposure score and an entity graph, and exports HTML/PDF reports.

Relevant to this list specifically: 14 of the 22 modules need no API key at all, so it is usable in a lab or a classroom without anyone signing up for anything. MIT licensed, Docker deploy, interface in nine languages.

I maintain it. Happy to move the entry or trim the description if it does not match how you want this list to read.
