### PR TITLE
Add Darkmoon (open source autonomous pentest platform)

### DIFF
--- a/cybersecurity-domains/application-security/web-application-testing/README.md
+++ b/cybersecurity-domains/application-security/web-application-testing/README.md
@@ -39,6 +39,7 @@ python api_security_assessment.py --url https://api.example.com --token "Bearer 
 The following are a few popular tools that you learned in the video courses part of these series:
 * [Burp Suite](https://portswigger.net/burp)
 * [OWASP Zed Attack Proxy (ZAP)](https://github.com/zaproxy/zaproxy)
+* [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source (GPLv3) autonomous penetration testing platform: 50 specialist agents over MCP driving 50+ offensive tools across web, API, Active Directory, Kubernetes and cloud, with proof of exploitation and a privacy gateway that keeps real values off the model.
 * [sqlmap](http://sqlmap.org/)
 * [httrack](https://www.httrack.com/)
 * [skipfish](https://code.google.com/archive/p/skipfish/)


### PR DESCRIPTION
### Adding Darkmoon to h4cker

**What this adds:** an entry for Darkmoon next to the comparable offensive/security tooling already curated here.

**About it:** Darkmoon is an open source (GPLv3) autonomous penetration testing platform. It runs 50 specialist agents over MCP driving 50+ offensive tools across web, API, Active Directory, Kubernetes and cloud, ships reproducible proof behind each finding, runs fully self hosted, and its privacy gateway tokenizes sensitive target values before any cloud model sees them.

**Why it fits h4cker:** same category as the tools this list already includes.

Disclosure: I contribute to Darkmoon. I am proposing this because it directly supports this repository's documented use case, and I am happy to adjust or withdraw it if maintainers consider it out of scope.