### PR TITLE
Add Malwagon to Sandboxing/Reversing tools

### DIFF
--- a/cybersecurity-domains/defensive-security/dfir/README.md
+++ b/cybersecurity-domains/defensive-security/dfir/README.md
@@ -249,6 +249,7 @@
 * [Cuckoo-modified](https://github.com/spender-sandbox/cuckoo-modified) - Heavily modified Cuckoo fork developed by community
 * [Cuckoo-modified-api](https://github.com/keithjjones/cuckoo-modified-api) - A Python library to control a cuckoo-modified sandbox
 * [Hybrid-Analysis](https://www.hybrid-analysis.com/) - Hybrid-Analysis is a free powerful online sandbox by Payload Security
+* [Malwagon](https://malwagon.com) - Malwagon is an online sandbox that detonates files and URLs on instrumented Windows and Linux virtual machines and returns behaviour, indicators and ATT&CK mappings, with a free community tier
 * [Malwr](https://malwr.com) - Malwr is a free online malware analysis service and community, which is powered by the Cuckoo Sandbox
 * [Mastiff](https://github.com/KoreLogicSecurity/mastiff) - MASTIFF is a static analysis framework that automates the process of extracting key characteristics from a number of different file formats
 * [Metadefender Cloud](https://www.metadefender.com) - Metadefender is a free threat intelligence platform providing multiscanning, data sanitization and vulnerability assesment of files


### PR DESCRIPTION
Adds [Malwagon](https://malwagon.com) to the Sandboxing/Reversing tools section of the DFIR page.

It detonates a submitted file or URL on instrumented Windows and Linux virtual machines and returns the process tree, registry and file activity, network traffic, extracted indicators and ATT&CK technique mappings. There is a free community tier that needs no payment details, so readers of this list can use it without a purchase.

Placed alphabetically between Hybrid-Analysis and Malwr, matching the existing `* [Name](URL) - Description` format used in that section.